### PR TITLE
chore: set up Dependabot with auto-merge and CI audit gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "version:patch"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "version:patch"
+    open-pull-requests-limit: 5

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,8 +11,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Skip Dependabot auto-merge commits
-    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
 
       - run: npm ci
 
+      # Block on high/critical only. Moderate vulns (e.g. dev-only build tool
+      # advisories) are surfaced via Dependabot PRs instead of breaking CI.
       - run: npm audit --audit-level=high
 
       - run: npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm audit --audit-level=high
+
       - run: npm run typecheck
 
       - run: npm test

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,19 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Set up Dependabot to automatically surface and merge dependency updates, and add a CI audit gate for high/critical vulns.

## Summary

- Add `.github/dependabot.yml` — weekly checks for npm deps and GitHub Actions versions. All Dependabot PRs get the `version:patch` label so the version label check passes and `auto-release` creates a patch release on merge (dep updates ship as real versioned releases since they can change deployed code)
- Add `dependabot-auto-merge.yml` — enables GitHub auto-merge on Dependabot PRs so they land automatically once CI passes
- Remove the Dependabot skip from `auto-release.yml` — no longer needed now that Dependabot PRs carry `version:patch`
- Add `npm audit --audit-level=high` to CI — hard-fails on high/critical vulns; moderate and below surface as Dependabot PRs rather than breaking the build (dev-only advisories like the current esbuild finding don't belong in a CI gate)

The esbuild/vite moderate vuln from #12 won't block CI (it's moderate severity, dev-only), but Dependabot will open a security PR for it. That one's a major version bump to vite v8, so it'll need manual review before merging.

## Branch protection

`dependabot-auto-merge.yml` calls `gh pr merge --auto`, which queues the merge and waits for required status checks before actually merging. If `main` has no branch protection rules, there are no required checks to wait on, so Dependabot PRs will merge immediately without CI running first.

To get the intended behavior (auto-merge only after CI passes), enable branch protection on `main` with at least the CI job marked as a required check: Settings → Branches → Add rule → "Require status checks to pass" → add the `test` job.

Closes #12

[#12]: https://github.com/jglopez/bill-split/issues/12