### PR TITLE
fix: release on every push to main, not just PR merges

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -19,10 +19,16 @@ jobs:
       - name: Get merged PR
         id: pr
         run: |
+          # Skip version-bump commits pushed by this workflow to avoid infinite loops.
+          COMMIT_EMAIL=$(git log -1 --format='%ae' "${{ github.sha }}")
+          if [ "$COMMIT_EMAIL" = "41898282+github-actions[bot]@users.noreply.github.com" ]; then
+            echo "Version-bump commit by github-actions[bot]; skipping." >&2
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
-            echo "No PR associated with this push; skipping release." >&2
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No PR found; will create patch release from commit."
             exit 0
           fi
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
@@ -90,7 +96,12 @@ jobs:
       - name: Create release
         if: steps.pr.outputs.skip != 'true'
         run: |
-          printf '%s\n\n%s\n\nPR: #%s\n' "$TITLE" "$BODY" "$PR_NUMBER" > notes.md
+          if [ -n "$PR_NUMBER" ]; then
+            printf '%s\n\n%s\n\nPR: #%s\n' "$TITLE" "$BODY" "$PR_NUMBER" > notes.md
+          else
+            COMMIT_MSG=$(git log -1 --format='%s' "${{ github.sha }}")
+            printf '%s\n\nCommit: %s\n' "$COMMIT_MSG" "${{ github.sha }}" > notes.md
+          fi
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file notes.md


### PR DESCRIPTION
## Summary

The `auto-release` workflow was skipping any push to `main` that had no associated PR, which meant direct commits (like the `corepack use npm@11.11.0` fix pushed straight to main) silently produced no release.

- Change the skip condition from "no PR" to "commit authored by `github-actions[bot]`" — that's the version-bump commit this workflow itself pushes, and we skip it specifically to avoid an infinite loop.
- When no PR exists, the bump type step already defaults to `patch` (empty labels), so no other steps need changing.
- Add a fallback for release notes when no PR: uses the commit subject line + SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)