### PR TITLE
Let Docker pick the host port for the dev service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       target: dev
     ports:
-      - "5173"
+      - "${DEV_PORT:-5173}"
     volumes:
       # Mount source for hot reload. The named volume keeps the container's
       # node_modules isolated from the host so they don't conflict.
@@ -13,6 +13,8 @@ services:
     environment:
       - NODE_ENV=development
       - BASE_PATH=/
+      - DEV_PORT=${DEV_PORT:-5173}
+    command: npm run dev -- --port ${DEV_PORT:-5173} --strictPort
 
 volumes:
   node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       target: dev
     ports:
-      - "5173:5173"
+      - "5173"
     volumes:
       # Mount source for hot reload. The named volume keeps the container's
       # node_modules isolated from the host so they don't conflict.


### PR DESCRIPTION
Drops the explicit host-side port binding so Docker assigns a free port at startup. Run \`docker compose port dev 5173\` to find where it landed.

The container port stays fixed at 5173 since that's what Vite listens on.