### PR TITLE
Revert #25, simplify dev port to 5173

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       target: dev
     ports:
-      - "5173:5173"
+      - "5173"
     volumes:
       # Mount source for hot reload. The named volume keeps the container's
       # node_modules isolated from the host so they don't conflict.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       target: dev
     ports:
-      - "${DEV_PORT:-5173}"
+      - "5173:5173"
     volumes:
       # Mount source for hot reload. The named volume keeps the container's
       # node_modules isolated from the host so they don't conflict.
@@ -13,8 +13,6 @@ services:
     environment:
       - NODE_ENV=development
       - BASE_PATH=/
-      - DEV_PORT=${DEV_PORT:-5173}
-    command: npm run dev -- --port ${DEV_PORT:-5173} --strictPort
 
 volumes:
   node_modules:


### PR DESCRIPTION
Reverts #25. The `DEV_PORT` env var approach was more complexity than it was worth.

Instead, just `"5173"` in `docker-compose.yml` — Docker maps container port 5173 to a random host port, which is the same intent without the env var plumbing.