### PR TITLE
Configure Vite dev server for Docker + OrbStack

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
   base: process.env.BASE_PATH ?? '/bill-split/',
   server: {
     allowedHosts: ['.orb.local'],
+    watch: {
+      usePolling: true,
+    },
   },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,4 +6,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: process.env.BASE_PATH ?? '/bill-split/',
+  server: {
+    allowedHosts: ['.orb.local'],
+  },
 })


### PR DESCRIPTION
## Summary

- Allow `.orb.local` hostnames so OrbStack's local domains aren't blocked by Vite's host check
- Enable file watch polling so HMR fires on changes to volume-mounted source files in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)