### PR TITLE
Sync column order across tables and improve column drag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { useBillSplit } from './hooks/useBillSplit'
+import { useColumnOrder } from './hooks/useColumnOrder'
 import { calculateBreakdown, calculateSettlement } from './utils/calculate'
 import { ParticipantSection } from './components/ParticipantSection'
 import { ItemsTable } from './components/ItemsTable'
@@ -28,6 +29,8 @@ export function App() {
     setAmountPaid,
     reset,
   } = useBillSplit()
+
+  const { columnOrder, setColumnOrder, orderedParticipants } = useColumnOrder(state.participants)
 
   // Recalculate on every render. The calculation is fast enough that memoizing
   // by individual field is not necessary, but useMemo avoids recomputing when
@@ -66,9 +69,11 @@ export function App() {
           <ItemsTable
             participants={state.participants}
             items={state.items}
+            columnOrder={columnOrder}
             onUpdateItem={updateItem}
             onRemoveItem={removeItem}
             onReorderItems={reorderItems}
+            onReorderColumns={setColumnOrder}
           />
 
           {/* Tax, tip, and additional fees */}
@@ -91,7 +96,7 @@ export function App() {
 
           {/* Summary table */}
           <SummarySection
-            participants={state.participants}
+            orderedParticipants={orderedParticipants}
             additionalFees={state.additionalFees}
             state={state}
             breakdown={breakdown}

--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react'
 import {
   DndContext,
   PointerSensor,
@@ -18,14 +17,14 @@ import { CSS } from '@dnd-kit/utilities'
 import type { Item, Participant } from '../types'
 import { isValidPrice } from '../utils/calculate'
 
-const COLUMN_ORDER_KEY = 'bill-split-column-order:v1'
-
 interface Props {
   participants: Participant[]
   items: Item[]
+  columnOrder: string[]
   onUpdateItem: (item: Item) => void
   onRemoveItem: (id: string) => void
   onReorderItems: (fromIndex: number, toIndex: number) => void
+  onReorderColumns: (newOrder: string[]) => void
 }
 
 /**
@@ -44,44 +43,11 @@ interface Props {
  *
  * Columns (participants) can be reordered by dragging the column header.
  * Rows (items) can be reordered by dragging the grip handle on the left.
- * Column order is a display preference stored in localStorage separately from
- * BillState. Row order updates BillState directly.
+ * Column order is managed by the parent via useColumnOrder and persisted in
+ * localStorage. Row order updates BillState directly.
  */
-export function ItemsTable({ participants, items, onUpdateItem, onRemoveItem, onReorderItems }: Props) {
+export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onRemoveItem, onReorderItems, onReorderColumns }: Props) {
   const allIds = participants.map(p => p.id)
-
-  const [columnOrder, setColumnOrder] = useState<string[]>(() => {
-    try {
-      const stored = localStorage.getItem(COLUMN_ORDER_KEY)
-      if (stored) {
-        const parsed = JSON.parse(stored) as unknown
-        if (Array.isArray(parsed)) {
-          const ids = parsed as string[]
-          const filtered = ids.filter(id => allIds.includes(id))
-          const added = allIds.filter(id => !ids.includes(id))
-          return [...filtered, ...added]
-        }
-      }
-    } catch {}
-    return [...allIds]
-  })
-
-  // Sync column order when participants are added or removed
-  useEffect(() => {
-    setColumnOrder(prev => {
-      const participantIds = participants.map(p => p.id)
-      const filtered = prev.filter(id => participantIds.includes(id))
-      const added = participantIds.filter(id => !prev.includes(id))
-      if (filtered.length === prev.length && added.length === 0) return prev
-      return [...filtered, ...added]
-    })
-  }, [participants])
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(COLUMN_ORDER_KEY, JSON.stringify(columnOrder))
-    } catch {}
-  }, [columnOrder])
 
   const orderedParticipants = columnOrder
     .map(id => participants.find(p => p.id === id))
@@ -99,12 +65,11 @@ export function ItemsTable({ participants, items, onUpdateItem, onRemoveItem, on
     const overType = over.data.current?.type as string | undefined
 
     if (activeType === 'column' && overType === 'column') {
-      setColumnOrder(prev => {
-        const oldIdx = prev.indexOf(active.id as string)
-        const newIdx = prev.indexOf(over.id as string)
-        if (oldIdx === -1 || newIdx === -1) return prev
-        return arrayMove(prev, oldIdx, newIdx)
-      })
+      const oldIdx = columnOrder.indexOf(active.id as string)
+      const newIdx = columnOrder.indexOf(over.id as string)
+      if (oldIdx !== -1 && newIdx !== -1) {
+        onReorderColumns(arrayMove(columnOrder, oldIdx, newIdx))
+      }
     } else if (activeType === 'row' && overType === 'row') {
       const draggable = items.slice(0, -1) // exclude trailing blank row
       const oldIdx = draggable.findIndex(i => i.id === active.id)

--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -1,10 +1,13 @@
+import { useState } from 'react'
 import {
   DndContext,
+  DragOverlay,
   PointerSensor,
   useSensor,
   useSensors,
   closestCenter,
   type DragEndEvent,
+  type DragStartEvent,
 } from '@dnd-kit/core'
 import {
   SortableContext,
@@ -53,11 +56,20 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
     .map(id => participants.find(p => p.id === id))
     .filter((p): p is Participant => p !== undefined)
 
+  const [activeColumnId, setActiveColumnId] = useState<string | null>(null)
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   )
 
+  function handleDragStart(event: DragStartEvent) {
+    if (event.active.data.current?.type === 'column') {
+      setActiveColumnId(event.active.id as string)
+    }
+  }
+
   function handleDragEnd(event: DragEndEvent) {
+    setActiveColumnId(null)
     const { active, over } = event
     if (!over || active.id === over.id) return
 
@@ -120,7 +132,7 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
 
   return (
     <div className="mb-2 overflow-x-auto -mx-4 px-4">
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
         <table className="w-full text-sm border-collapse min-w-[500px]">
           <thead>
             <tr className="border-b border-gray-200">
@@ -196,7 +208,7 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
                           : 0
 
                       return (
-                        <td key={p.id} className="py-1 px-1 text-center">
+                        <td key={p.id} className="py-1 px-1 text-center" style={{ opacity: activeColumnId === p.id ? 0.4 : undefined }}>
                           {blank ? (
                             <span className="text-gray-300 text-xs">—</span>
                           ) : (
@@ -270,7 +282,60 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
             </SortableContext>
           </tbody>
         </table>
+        <DragOverlay>
+          {activeColumnId && (() => {
+            const participant = orderedParticipants.find(p => p.id === activeColumnId)
+            if (!participant) return null
+            return <ColumnDragOverlay participant={participant} items={items} participants={participants} />
+          })()}
+        </DragOverlay>
       </DndContext>
+    </div>
+  )
+}
+
+// ─── Column drag overlay ──────────────────────────────────────────────────────
+
+function ColumnDragOverlay({
+  participant,
+  items,
+  participants,
+}: {
+  participant: Participant
+  items: Item[]
+  participants: Participant[]
+}) {
+  const displayItems = items.slice(0, -1) // exclude trailing blank row
+  return (
+    <div className="bg-white shadow-xl rounded border border-gray-300 w-20 overflow-hidden">
+      <div className="text-center py-2 px-1 border-b-2 border-gray-200">
+        <span className="block text-xs leading-tight max-w-[70px] mx-auto break-words font-medium text-gray-600">
+          {participant.name}
+        </span>
+      </div>
+      {displayItems.map(item => {
+        const assigned = item.assignedTo === null || item.assignedTo.includes(participant.id)
+        const price = Number(item.price)
+        const assignedCount = item.assignedTo === null ? participants.length : item.assignedTo.length
+        const share =
+          assigned && !isNaN(price) && price > 0 && assignedCount > 0
+            ? price / assignedCount
+            : 0
+        return (
+          <div key={item.id} className="py-1 px-1 text-center border-b border-gray-100 flex flex-col items-center gap-0.5">
+            <span
+              className={`w-5 h-5 rounded flex items-center justify-center border ${
+                assigned ? 'bg-teal-600 border-teal-600 text-white' : 'border-gray-300 bg-white'
+              }`}
+            >
+              {assigned && <CheckIcon />}
+            </span>
+            <span className="text-xs text-gray-600 tabular-nums">
+              {share > 0 ? fmt(share) : <span className="text-gray-300">—</span>}
+            </span>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/components/SummarySection.tsx
+++ b/src/components/SummarySection.tsx
@@ -23,12 +23,14 @@ interface Props {
 export function SummarySection({ orderedParticipants, additionalFees, state, breakdown }: Props) {
   if (orderedParticipants.length === 0 || breakdown.totalSubtotal === 0) return null
 
+  const perPersonMap = new Map(breakdown.perPerson.map(p => [p.participantId, p]))
+
   function perPersonValue(participantId: string, field: 'subtotal' | 'tax' | 'tip' | 'grandTotal'): number {
-    return breakdown.perPerson.find(p => p.participantId === participantId)?.[field] ?? 0
+    return perPersonMap.get(participantId)?.[field] ?? 0
   }
 
   function perPersonFee(participantId: string, feeIndex: number): number {
-    return breakdown.perPerson.find(p => p.participantId === participantId)?.additionalFees[feeIndex] ?? 0
+    return perPersonMap.get(participantId)?.additionalFees[feeIndex] ?? 0
   }
 
   return (

--- a/src/components/SummarySection.tsx
+++ b/src/components/SummarySection.tsx
@@ -2,7 +2,7 @@ import type { AdditionalFee, BillState, Participant } from '../types'
 import type { BillBreakdown } from '../utils/calculate'
 
 interface Props {
-  participants: Participant[]
+  orderedParticipants: Participant[]
   additionalFees: AdditionalFee[]
   state: BillState
   breakdown: BillBreakdown
@@ -12,12 +12,24 @@ interface Props {
  * Read-only summary table showing each person's share of:
  * subtotal → tax → tip → each additional fee → grand total.
  *
+ * Columns are rendered in the same order as ItemsTable (controlled by
+ * useColumnOrder in App). Per-person values are looked up by participantId
+ * rather than relying on parallel index ordering.
+ *
  * This is intentionally display-only; all interactive inputs live in the
  * sections above. Rendering it separately keeps the component boundary clear
  * and makes it easy to extract into an export/print view later.
  */
-export function SummarySection({ participants, additionalFees, state, breakdown }: Props) {
-  if (participants.length === 0 || breakdown.totalSubtotal === 0) return null
+export function SummarySection({ orderedParticipants, additionalFees, state, breakdown }: Props) {
+  if (orderedParticipants.length === 0 || breakdown.totalSubtotal === 0) return null
+
+  function perPersonValue(participantId: string, field: 'subtotal' | 'tax' | 'tip' | 'grandTotal'): number {
+    return breakdown.perPerson.find(p => p.participantId === participantId)?.[field] ?? 0
+  }
+
+  function perPersonFee(participantId: string, feeIndex: number): number {
+    return breakdown.perPerson.find(p => p.participantId === participantId)?.additionalFees[feeIndex] ?? 0
+  }
 
   return (
     <div className="mt-4 overflow-x-auto -mx-4 px-4">
@@ -26,7 +38,7 @@ export function SummarySection({ participants, additionalFees, state, breakdown 
           <tr className="border-b-2 border-gray-200">
             <th className="text-left py-2 pr-3 font-medium text-gray-600 w-[35%]" />
             <th className="text-right py-2 px-2 font-semibold text-gray-700 w-20">Total</th>
-            {participants.map(p => (
+            {orderedParticipants.map(p => (
               <th
                 key={p.id}
                 className="text-right py-2 px-2 font-medium text-gray-600 w-20"
@@ -43,7 +55,7 @@ export function SummarySection({ participants, additionalFees, state, breakdown 
           <SummaryRow
             label="Subtotal"
             total={breakdown.totalSubtotal}
-            values={breakdown.perPerson.map(p => p.subtotal)}
+            values={orderedParticipants.map(p => perPersonValue(p.id, 'subtotal'))}
           />
 
           {/* Tax */}
@@ -51,7 +63,7 @@ export function SummarySection({ participants, additionalFees, state, breakdown 
             <SummaryRow
               label={`+ Tax ${state.tax ? `(${state.tax})` : ''}`}
               total={breakdown.totalTax}
-              values={breakdown.perPerson.map(p => p.tax)}
+              values={orderedParticipants.map(p => perPersonValue(p.id, 'tax'))}
             />
           )}
 
@@ -60,7 +72,7 @@ export function SummarySection({ participants, additionalFees, state, breakdown 
             <SummaryRow
               label={`+ Tip ${state.tip ? `(${state.tip})` : ''}${state.tipBase === 'post-tax' ? ' incl. tax' : ''}`}
               total={breakdown.totalTip}
-              values={breakdown.perPerson.map(p => p.tip)}
+              values={orderedParticipants.map(p => perPersonValue(p.id, 'tip'))}
             />
           )}
 
@@ -74,7 +86,7 @@ export function SummarySection({ participants, additionalFees, state, breakdown 
                 key={fee.id}
                 label={`${isDiscount ? '−' : '+'} ${fee.name || (isDiscount ? 'Discount' : 'Fee')} ${fee.amount ? `(${fee.amount})` : ''}${fee.base === 'post-tax' ? ' incl. tax' : ''}`}
                 total={total}
-                values={breakdown.perPerson.map(p => p.additionalFees[i])}
+                values={orderedParticipants.map(p => perPersonFee(p.id, i))}
                 isDiscount={isDiscount}
               />
             )
@@ -86,9 +98,9 @@ export function SummarySection({ participants, additionalFees, state, breakdown 
             <td className="py-2 px-2 text-right text-gray-800 tabular-nums">
               {fmt(breakdown.totalGrandTotal)}
             </td>
-            {breakdown.perPerson.map(p => (
-              <td key={p.participantId} className="py-2 px-2 text-right text-gray-800 tabular-nums">
-                {fmt(p.grandTotal)}
+            {orderedParticipants.map(p => (
+              <td key={p.id} className="py-2 px-2 text-right text-gray-800 tabular-nums">
+                {fmt(perPersonValue(p.id, 'grandTotal'))}
               </td>
             ))}
           </tr>

--- a/src/hooks/useColumnOrder.ts
+++ b/src/hooks/useColumnOrder.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react'
+import type { Participant } from '../types'
+
+const COLUMN_ORDER_KEY = 'bill-split-column-order:v1'
+
+/**
+ * Manages participant column display order, persisted to localStorage.
+ *
+ * Defaults to insertion order. New participants are appended; removed
+ * participants are dropped. The stored order survives page refreshes.
+ */
+export function useColumnOrder(participants: Participant[]): {
+  columnOrder: string[]
+  setColumnOrder: React.Dispatch<React.SetStateAction<string[]>>
+  orderedParticipants: Participant[]
+} {
+  const [columnOrder, setColumnOrder] = useState<string[]>(() => {
+    const allIds = participants.map(p => p.id)
+    try {
+      const stored = localStorage.getItem(COLUMN_ORDER_KEY)
+      if (stored) {
+        const parsed = JSON.parse(stored) as unknown
+        if (Array.isArray(parsed)) {
+          const ids = parsed as string[]
+          const filtered = ids.filter(id => allIds.includes(id))
+          const added = allIds.filter(id => !ids.includes(id))
+          return [...filtered, ...added]
+        }
+      }
+    } catch {}
+    return [...allIds]
+  })
+
+  // Sync when participants are added or removed
+  useEffect(() => {
+    setColumnOrder(prev => {
+      const participantIds = participants.map(p => p.id)
+      const filtered = prev.filter(id => participantIds.includes(id))
+      const added = participantIds.filter(id => !prev.includes(id))
+      if (filtered.length === prev.length && added.length === 0) return prev
+      return [...filtered, ...added]
+    })
+  }, [participants])
+
+  // Persist to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(COLUMN_ORDER_KEY, JSON.stringify(columnOrder))
+    } catch {}
+  }, [columnOrder])
+
+  const orderedParticipants = columnOrder
+    .map(id => participants.find(p => p.id === id))
+    .filter((p): p is Participant => p !== undefined)
+
+  return { columnOrder, setColumnOrder, orderedParticipants }
+}

--- a/src/hooks/useColumnOrder.ts
+++ b/src/hooks/useColumnOrder.ts
@@ -21,7 +21,9 @@ export function useColumnOrder(participants: Participant[]): {
       if (stored) {
         const parsed = JSON.parse(stored) as unknown
         if (Array.isArray(parsed)) {
-          const ids = parsed as string[]
+          // Deduplicate before filtering so corrupt/duplicate localStorage data
+          // can't produce duplicate columns.
+          const ids = [...new Set(parsed as string[])]
           const filtered = ids.filter(id => allIds.includes(id))
           const added = allIds.filter(id => !ids.includes(id))
           return [...filtered, ...added]
@@ -49,8 +51,9 @@ export function useColumnOrder(participants: Participant[]): {
     } catch {}
   }, [columnOrder])
 
+  const participantMap = new Map(participants.map(p => [p.id, p]))
   const orderedParticipants = columnOrder
-    .map(id => participants.find(p => p.id === id))
+    .map(id => participantMap.get(id))
     .filter((p): p is Participant => p !== undefined)
 
   return { columnOrder, setColumnOrder, orderedParticipants }


### PR DESCRIPTION
Dragging a column header in the items table now reorders that column in the breakdown summary below it too.

- Extract `useColumnOrder` hook from `ItemsTable` so the localStorage init/sync/persist logic lives in one place
- `ItemsTable` accepts `columnOrder` and `onReorderColumns` as props; `App` calls the hook and passes results down
- `SummarySection` accepts `orderedParticipants` instead of `participants`, and looks up per-person values by `participantId` rather than by index

Closes #29