### PR TITLE
Fix column drag to first position

### DIFF
--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -6,6 +6,7 @@ import {
   useSensor,
   useSensors,
   closestCenter,
+  type CollisionDetection,
   type DragEndEvent,
   type DragStartEvent,
 } from '@dnd-kit/core'
@@ -61,6 +62,18 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   )
+
+  const collisionDetection: CollisionDetection = (args) => {
+    if (activeColumnId !== null) {
+      return closestCenter({
+        ...args,
+        droppableContainers: args.droppableContainers.filter(
+          c => c.data.current?.type === 'column',
+        ),
+      })
+    }
+    return closestCenter(args)
+  }
 
   function handleDragStart(event: DragStartEvent) {
     if (event.active.data.current?.type === 'column') {
@@ -132,7 +145,7 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
 
   return (
     <div className="mb-2 overflow-x-auto -mx-4 px-4">
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <DndContext sensors={sensors} collisionDetection={collisionDetection} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
         <table className="w-full text-sm border-collapse min-w-[500px]">
           <thead>
             <tr className="border-b border-gray-200">


### PR DESCRIPTION
When dragging any column past the left edge of the first column, the column snapped back instead of landing at position 0. The only workaround was to first move the first column right, then drag the other column into its place.

Both column headers and row items share one `DndContext`. `closestCenter` considers all registered droppables, so when the cursor moved past the first column into the table body, it picked a row as the `over` target. The `overType === 'column'` check in `handleDragEnd` then failed silently.

I added a custom collision detection function that filters droppable containers to column-type only while a column drag is active (`activeColumnId !== null`), then delegates to `closestCenter`. Row drag-and-drop is unaffected since the filter only kicks in during column drags.

Tested with 4 participants: dragged the last column past the left edge of the first — it now lands at position 0. Dragging from first to last also works. Row reordering still works normally.