### PR TITLE
fix: prevent iOS Safari auto-zoom on text input focus

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,10 @@
 @import "tailwindcss";
+
+/* Prevent iOS Safari from auto-zooming on input focus.
+   Safari zooms in when font-size < 16px and doesn't zoom back out. */
+@media (max-width: 639px) {
+  input[type="text"],
+  input[type="number"] {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
iOS Safari auto-zooms the viewport when a text input has `font-size < 16px` and doesn't zoom back out after the keyboard dismisses. Every text input in the app uses `text-sm` (14px), so any input tap triggers this.

Fix is a single rule in `src/index.css` — `font-size: 16px` on `input[type="text"]` and `input[type="number"]` below the `sm` breakpoint (639px). Desktop layout is unchanged.

Verified locally in Chrome DevTools with iPhone simulation — inputs no longer cause a zoom event on focus.

Closes #39. Related to #33 (some of the over-scroll symptoms on iOS are likely the viewport jumping after this zoom — noted in [#33 (comment)](https://github.com/jglopez/bill-split/issues/33#issuecomment-4212099215)).