### PR TITLE
feat: confirm before resetting bill data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useBillSplit } from './hooks/useBillSplit'
 import { useColumnOrder } from './hooks/useColumnOrder'
 import { calculateBreakdown, calculateSettlement } from './utils/calculate'
@@ -8,6 +8,7 @@ import { TaxTipSection } from './components/TaxTipSection'
 import { SummarySection } from './components/SummarySection'
 import { PayerSection } from './components/PayerSection'
 import { SettlementSection } from './components/SettlementSection'
+import { ConfirmModal } from './components/ConfirmModal'
 
 export function App() {
   const {
@@ -31,6 +32,7 @@ export function App() {
   } = useBillSplit()
 
   const { columnOrder, setColumnOrder, orderedParticipants } = useColumnOrder(state.participants)
+  const [showResetModal, setShowResetModal] = useState(false)
 
   // Recalculate on every render. The calculation is fast enough that memoizing
   // by individual field is not necessary, but useMemo avoids recomputing when
@@ -48,7 +50,7 @@ export function App() {
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-2xl font-bold text-gray-900">Bill Split</h1>
           <button
-            onClick={reset}
+            onClick={() => setShowResetModal(true)}
             aria-label="Reset all fields and start over"
             className="text-sm text-gray-400 hover:text-red-500 focus:outline-none focus:text-red-500 transition-colors px-3 py-1.5 rounded border border-transparent hover:border-red-200 focus:border-red-200 min-h-[44px]"
           >
@@ -119,6 +121,15 @@ export function App() {
           />
         </div>
       </div>
+      {showResetModal && (
+        <ConfirmModal
+          title="Reset everything?"
+          message="This will clear all participants, items, and settings. It can't be undone."
+          confirmLabel="Reset"
+          onConfirm={() => { reset(); setShowResetModal(false) }}
+          onCancel={() => setShowResetModal(false)}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from 'react'
+
+interface ConfirmModalProps {
+  title: string
+  message: string
+  confirmLabel?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmModal({
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onCancel])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      aria-modal="true"
+      role="dialog"
+      aria-labelledby="confirm-modal-title"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onCancel}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div className="relative bg-white rounded-xl shadow-lg w-full max-w-sm p-6">
+        <h2 id="confirm-modal-title" className="text-base font-semibold text-gray-900 mb-2">
+          {title}
+        </h2>
+        <p className="text-sm text-gray-500 mb-6">{message}</p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 border border-gray-200 hover:border-gray-300 rounded-lg transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 text-sm text-white bg-red-500 hover:bg-red-600 rounded-lg transition-colors"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Reset previously cleared everything immediately with no warning — easy to trigger by accident.

Added a `ConfirmModal` component and wired it to the reset button. Clicking Reset now opens a modal; the state only clears if the user confirms.

#### What's in the modal

- Title: "Reset everything?"
- Message: "This will clear all participants, items, and settings. It can't be undone."
- Cancel (dismisses, no change) and Reset (red, destructive) buttons
- Closes on Escape or backdrop click

Closes #40.