### PR TITLE
Mobile UX improvements: overscroll, summary cards, numeric inputs

### DIFF
--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -144,7 +144,7 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
   const isLastRow = (item: Item) => item === items[items.length - 1]
 
   return (
-    <div className="mb-2 overflow-x-auto -mx-4 px-4">
+    <div className="mb-2 overflow-x-auto overscroll-x-none -mx-4 px-4">
       <DndContext sensors={sensors} collisionDetection={collisionDetection} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
         <table className="w-full text-sm border-collapse min-w-[500px]">
           <thead>

--- a/src/components/SummarySection.tsx
+++ b/src/components/SummarySection.tsx
@@ -69,7 +69,7 @@ export function SummarySection({ orderedParticipants, additionalFees, state, bre
                 return (
                   <CardRow
                     key={fee.id}
-                    label={`${isDiscount ? '−' : '+'} ${fee.name || (isDiscount ? 'Discount' : 'Fee')}${fee.amount ? ` (${fee.amount})` : ''}`}
+                    label={`${isDiscount ? '−' : '+'} ${fee.name || (isDiscount ? 'Discount' : 'Fee')}${fee.amount ? ` (${fee.amount})` : ''}${fee.base === 'post-tax' ? ' incl. tax' : ''}`}
                     value={feeAmount}
                     isDiscount={isDiscount}
                   />

--- a/src/components/SummarySection.tsx
+++ b/src/components/SummarySection.tsx
@@ -34,7 +34,7 @@ export function SummarySection({ orderedParticipants, additionalFees, state, bre
   }
 
   return (
-    <div className="mt-4 overflow-x-auto -mx-4 px-4">
+    <div className="mt-4 overflow-x-auto overscroll-x-none -mx-4 px-4">
       <table className="w-full text-sm border-collapse min-w-[400px]">
         <thead>
           <tr className="border-b-2 border-gray-200">

--- a/src/components/SummarySection.tsx
+++ b/src/components/SummarySection.tsx
@@ -1,5 +1,6 @@
 import type { AdditionalFee, BillState, Participant } from '../types'
 import type { BillBreakdown } from '../utils/calculate'
+import { useIsMobile } from '../hooks/useIsMobile'
 
 interface Props {
   orderedParticipants: Participant[]
@@ -16,6 +17,9 @@ interface Props {
  * useColumnOrder in App). Per-person values are looked up by participantId
  * rather than relying on parallel index ordering.
  *
+ * On narrow screens (below sm breakpoint) each participant is rendered as
+ * a stacked card instead of a column in the table.
+ *
  * This is intentionally display-only; all interactive inputs live in the
  * sections above. Rendering it separately keeps the component boundary clear
  * and makes it easy to extract into an export/print view later.
@@ -23,6 +27,7 @@ interface Props {
 export function SummarySection({ orderedParticipants, additionalFees, state, breakdown }: Props) {
   if (orderedParticipants.length === 0 || breakdown.totalSubtotal === 0) return null
 
+  const isMobile = useIsMobile()
   const perPersonMap = new Map(breakdown.perPerson.map(p => [p.participantId, p]))
 
   function perPersonValue(participantId: string, field: 'subtotal' | 'tax' | 'tip' | 'grandTotal'): number {
@@ -31,6 +36,54 @@ export function SummarySection({ orderedParticipants, additionalFees, state, bre
 
   function perPersonFee(participantId: string, feeIndex: number): number {
     return perPersonMap.get(participantId)?.additionalFees[feeIndex] ?? 0
+  }
+
+  if (isMobile) {
+    return (
+      <div className="mt-4 space-y-3">
+        {orderedParticipants.map(p => {
+          const subtotal = perPersonValue(p.id, 'subtotal')
+          const tax = perPersonValue(p.id, 'tax')
+          const tip = perPersonValue(p.id, 'tip')
+          const grandTotal = perPersonValue(p.id, 'grandTotal')
+          return (
+            <div key={p.id} className="rounded-lg border border-gray-200 px-4 py-3 text-sm">
+              <div className="font-medium text-gray-800 mb-2">{p.name}</div>
+              <CardRow label="Subtotal" value={subtotal} />
+              {breakdown.totalTax !== 0 && (
+                <CardRow
+                  label={`+ Tax${state.tax ? ` (${state.tax})` : ''}`}
+                  value={tax}
+                />
+              )}
+              {breakdown.totalTip !== 0 && (
+                <CardRow
+                  label={`+ Tip${state.tip ? ` (${state.tip})` : ''}${state.tipBase === 'post-tax' ? ' incl. tax' : ''}`}
+                  value={tip}
+                />
+              )}
+              {additionalFees.map((fee, i) => {
+                const feeAmount = perPersonFee(p.id, i)
+                if (breakdown.totalAdditionalFees[i] === 0) return null
+                const isDiscount = feeAmount < 0
+                return (
+                  <CardRow
+                    key={fee.id}
+                    label={`${isDiscount ? '−' : '+'} ${fee.name || (isDiscount ? 'Discount' : 'Fee')}${fee.amount ? ` (${fee.amount})` : ''}`}
+                    value={feeAmount}
+                    isDiscount={isDiscount}
+                  />
+                )
+              })}
+              <div className="flex justify-between border-t border-gray-300 mt-2 pt-2 font-semibold text-gray-800">
+                <span>Total</span>
+                <span className="tabular-nums">{fmt(grandTotal)}</span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    )
   }
 
   return (
@@ -112,7 +165,27 @@ export function SummarySection({ orderedParticipants, additionalFees, state, bre
   )
 }
 
-// ─── Row ──────────────────────────────────────────────────────────────────────
+// ─── Mobile card row ──────────────────────────────────────────────────────────
+
+function CardRow({
+  label,
+  value,
+  isDiscount = false,
+}: {
+  label: string
+  value: number
+  isDiscount?: boolean
+}) {
+  const colorClass = isDiscount ? 'text-green-700' : 'text-gray-600'
+  return (
+    <div className={`flex justify-between py-0.5 text-xs ${colorClass}`}>
+      <span>{label}</span>
+      <span className="tabular-nums">{fmt(value)}</span>
+    </div>
+  )
+}
+
+// ─── Desktop table row ────────────────────────────────────────────────────────
 
 function SummaryRow({
   label,

--- a/src/components/TaxTipSection.tsx
+++ b/src/components/TaxTipSection.tsx
@@ -26,9 +26,9 @@ interface Props {
  * just reduces each person's share instead of increasing it.
  *
  * Amount fields accept either a plain dollar amount ("15.00") or a percentage
- * ("18%"). The "%" suffix is detected on input so users don't need a separate
- * toggle. These fields use inputMode="text" (not "decimal") to allow the "%"
- * character on mobile keyboards.
+ * ("18%"). The "%" state is controlled by a toggle button next to the input,
+ * so the input itself uses inputMode="decimal" for a numeric keypad on mobile.
+ * Typing "%" directly in the input is also supported for desktop users.
  */
 export function TaxTipSection({
   tax,
@@ -54,7 +54,7 @@ export function TaxTipSection({
           value={tax}
           onChange={onSetTax}
           invalid={taxInvalid}
-          placeholder="e.g. 10%"
+          placeholder="e.g. 10"
           label="Tax amount"
         />
         {taxInvalid && (
@@ -69,7 +69,7 @@ export function TaxTipSection({
           value={tip}
           onChange={onSetTip}
           invalid={tipInvalid}
-          placeholder="e.g. 20%"
+          placeholder="e.g. 20"
           label="Tip amount"
         />
         <IncludeTaxToggle
@@ -121,6 +121,12 @@ function FeeRow({
   const numAmount = Number(trimmedAmount.endsWith('%') ? trimmedAmount.slice(0, -1) : trimmedAmount)
   const isDiscount = trimmedAmount.startsWith('-') || (!isNaN(numAmount) && numAmount < 0)
 
+  function toggleSign() {
+    const t = fee.amount.trim()
+    const next = t.startsWith('-') ? t.slice(1) : '-' + t
+    onChange({ ...fee, amount: next })
+  }
+
   return (
     <div className="flex items-center gap-2 text-sm flex-wrap">
       <span className="w-24 text-gray-600 shrink-0">
@@ -142,9 +148,22 @@ function FeeRow({
         value={fee.amount}
         onChange={v => onChange({ ...fee, amount: v })}
         invalid={amountInvalid}
-        placeholder="e.g. 5% or -5%"
+        placeholder="e.g. 5"
         label={`${fee.name || 'fee'} amount`}
       />
+      <button
+        type="button"
+        onClick={toggleSign}
+        aria-label={isDiscount ? 'Switch to positive fee' : 'Switch to discount'}
+        aria-pressed={isDiscount}
+        className={`text-xs px-1.5 py-0.5 rounded border transition-colors ${
+          isDiscount
+            ? 'border-green-500 text-green-700 bg-green-50'
+            : 'border-gray-300 text-gray-400 hover:border-gray-400 hover:text-gray-500'
+        }`}
+      >
+        {isDiscount ? '−' : '+/−'}
+      </button>
       <IncludeTaxToggle
         base={fee.base}
         onChange={b => onChange({ ...fee, base: b })}
@@ -178,22 +197,56 @@ function AmountInput({
   placeholder: string
   label: string
 }) {
+  // Parse into numeric portion and percent flag.
+  // A trailing "%" in the stored value means percent mode is on.
+  const trimmed = value.trim()
+  const isPercent = trimmed.endsWith('%')
+  const numeric = isPercent ? trimmed.slice(0, -1) : trimmed
+
+  function handleInputChange(raw: string) {
+    // Support desktop users who type "%" directly — strip it from the input
+    // and encode it as the percent flag instead.
+    if (raw.endsWith('%')) {
+      onChange(raw.slice(0, -1) + '%')
+    } else {
+      onChange(raw + (isPercent ? '%' : ''))
+    }
+  }
+
+  function handleTogglePercent() {
+    onChange(isPercent ? numeric : numeric + '%')
+  }
+
   return (
-    <input
-      type="text"
-      // "text" instead of "decimal" so the % character is available on mobile
-      inputMode="text"
-      value={value}
-      onChange={e => onChange(e.target.value)}
-      placeholder={placeholder}
-      aria-label={label}
-      aria-invalid={invalid}
-      className={`border-b border-dashed focus:outline-none bg-transparent py-0.5 w-24 tabular-nums ${
-        invalid
-          ? 'border-red-400 text-red-600'
-          : 'border-gray-300 focus:border-gray-500 text-gray-800'
-      } placeholder-gray-300`}
-    />
+    <span className="inline-flex items-center gap-1">
+      <input
+        type="text"
+        inputMode="decimal"
+        value={numeric}
+        onChange={e => handleInputChange(e.target.value)}
+        placeholder={placeholder}
+        aria-label={label}
+        aria-invalid={invalid}
+        className={`border-b border-dashed focus:outline-none bg-transparent py-0.5 w-20 tabular-nums ${
+          invalid
+            ? 'border-red-400 text-red-600'
+            : 'border-gray-300 focus:border-gray-500 text-gray-800'
+        } placeholder-gray-300`}
+      />
+      <button
+        type="button"
+        onClick={handleTogglePercent}
+        aria-label={isPercent ? 'Switch to dollar amount' : 'Switch to percentage'}
+        aria-pressed={isPercent}
+        className={`text-xs px-1 py-0.5 rounded border transition-colors ${
+          isPercent
+            ? 'border-teal-500 text-teal-600 bg-teal-50'
+            : 'border-gray-300 text-gray-400 hover:border-gray-400 hover:text-gray-500'
+        }`}
+      >
+        %
+      </button>
+    </span>
   )
 }
 

--- a/src/components/TaxTipSection.tsx
+++ b/src/components/TaxTipSection.tsx
@@ -204,10 +204,10 @@ function AmountInput({
   const numeric = isPercent ? trimmed.slice(0, -1) : trimmed
 
   function handleInputChange(raw: string) {
-    // Support desktop users who type "%" directly — strip it from the input
-    // and encode it as the percent flag instead.
+    // "%" typed directly acts as a toggle: turns percent mode on if off,
+    // off if already on. This mirrors the behavior of the % button.
     if (raw.endsWith('%')) {
-      onChange(raw.slice(0, -1) + '%')
+      onChange(raw.slice(0, -1) + (isPercent ? '' : '%'))
     } else {
       onChange(raw + (isPercent ? '%' : ''))
     }

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * Returns true when the viewport width is below the Tailwind `sm` breakpoint
+ * (640px). Updates reactively on window resize.
+ */
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 640)
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerWidth < 640)
+    window.addEventListener('resize', handler)
+    return () => window.removeEventListener('resize', handler)
+  }, [])
+  return isMobile
+}

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -5,9 +5,11 @@ import { useState, useEffect } from 'react'
  * (640px). Updates reactively on window resize.
  */
 export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 640)
+  const [isMobile, setIsMobile] = useState(false)
   useEffect(() => {
+    if (typeof window === 'undefined') return
     const handler = () => setIsMobile(window.innerWidth < 640)
+    handler()
     window.addEventListener('resize', handler)
     return () => window.removeEventListener('resize', handler)
   }, [])

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+/* Prevent iOS rubber-band scrolling from exposing blank canvas on either side
+   of horizontally-scrollable tables. */
+html, body {
+  overscroll-behavior-x: none;
+}
+
 /* Prevent iOS Safari from auto-zooming on input focus.
    Safari zooms in when font-size < 16px and doesn't zoom back out. */
 @media (max-width: 639px) {


### PR DESCRIPTION
## Summary

Three mobile improvements from #32:

- **#33** — `overscroll-behavior-x: none` on `html`/`body` and on the scroll containers in `ItemsTable` and `SummarySection`. Prevents iOS from rubber-band dragging past the table edges and exposing blank canvas.

- **#38** — Below the `sm` breakpoint (640px), `SummarySection` switches from a horizontal-scroll table to a stacked per-person card layout. Each card shows subtotal, tax, tip, fees, and total for that person. Desktop table is unchanged.

- **#36** (extended from original) — `AmountInput` in `TaxTipSection` now uses `inputMode="decimal"` so mobile users get a numeric keypad. A `%` toggle button next to each field replaces the need to type `%` directly. Fee rows get a `+/−` toggle to mark a fee as a discount, replacing the leading-minus approach on mobile. Typing `%` or `-` directly still works on desktop — state format is unchanged (`"18%"`, `"-5%"`).

Also adds `src/hooks/useIsMobile.ts` — a small hook used by `SummarySection` to detect the `sm` breakpoint reactively.

## Related

Closes #33, #36, #38
Part of #32