### PR TITLE
fix: hide incl. tax toggle when amount is a flat dollar value

### DIFF
--- a/src/components/TaxTipSection.tsx
+++ b/src/components/TaxTipSection.tsx
@@ -75,6 +75,7 @@ export function TaxTipSection({
         <IncludeTaxToggle
           base={tipBase}
           onChange={onSetTipBase}
+          disabled={!tip.trim().endsWith('%')}
         />
         {tipInvalid && (
           <span role="alert" className="text-xs text-red-600">Invalid amount</span>
@@ -167,6 +168,7 @@ function FeeRow({
       <IncludeTaxToggle
         base={fee.base}
         onChange={b => onChange({ ...fee, base: b })}
+        disabled={!fee.amount.trim().endsWith('%')}
       />
       {amountInvalid && (
         <span role="alert" className="text-xs text-red-600">Invalid amount</span>
@@ -257,11 +259,18 @@ function AmountInput({
 function IncludeTaxToggle({
   base,
   onChange,
+  disabled = false,
 }: {
   base: FeesBase
   onChange: (b: FeesBase) => void
+  disabled?: boolean
 }) {
   const id = useId()
+
+  if (disabled) {
+    return <Tooltip text="Switch to % to calculate this on the pre- or post-tax subtotal." />
+  }
+
   return (
     <span className="flex items-center gap-1 text-xs text-gray-500">
       <input


### PR DESCRIPTION
The \"incl. tax\" toggle only affects the calculation when the amount is a percentage. `parseAmount` uses the base (pre-tax vs post-tax subtotal) only when the value ends with `%` — a flat dollar amount returns as-is regardless of base, so the toggle was a no-op for flat inputs.

When the amount is a flat dollar value, I now hide the checkbox and label and render a `?` tooltip in their place that says "Switch to % to calculate this on the pre- or post-tax subtotal." When the user switches to %, the full toggle reappears as normal.

Applies to both the tip row and additional fee rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)