### PR TITLE
fix: two regressions from Chainguard base image switch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,5 @@ RUN npm run build
 # Chainguard nginx runs as non-root, so port 8080 is used instead of 80.
 FROM cgr.dev/chainguard/nginx:latest AS prod
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/nginx.default.conf
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 EXPOSE 5173
+# Chainguard node sets ENTRYPOINT ["node"]; clear it so this exec-form CMD runs `npm`
+# directly instead of having `npm` treated as a Node script/module.
 # --host binds Vite to 0.0.0.0 so the port is reachable from outside the container.
+ENTRYPOINT []
 CMD ["npm", "run", "dev", "--", "--host"]
 
 # ── builder ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Two regressions from #45, both fixed here.

**Dev (`docker compose up` crash)**
Chainguard's node image sets `ENTRYPOINT ["node"]`, so `CMD ["npm", "run", "dev", ...]` was resolving to `node npm ...` — treating `npm` as a Node.js module path:

```
Error: Cannot find module '/app/npm'
```

Fix: `ENTRYPOINT []` in the dev stage clears the inherited entrypoint before CMD.

**Prod (SPA routing broken)**
Chainguard's nginx image ships a default server block at `/etc/nginx/conf.d/nginx.default.conf` with `server_name localhost` but no SPA fallback. Our config was written to `default.conf` (a separate file), so requests with `Host: localhost` matched Chainguard's block instead of ours — meaning `try_files` never ran and unknown routes returned 404.

Fix: copy our config to `nginx.default.conf` to replace Chainguard's default rather than adding a second competing server block.

Validated locally:
- `docker compose up --build` — Vite ready, port assigned by Docker
- `docker run -p 8080:8080 bill-split` — `/`, `/split`, `/nonexistent` all 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)