### PR TITLE
docs: mention fnm as alternative to nvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ An itemized bill-splitting tool. Add participants, enter line items, assign them
 ## Running locally
 
 ```bash
-nvm use   # picks up the version from .nvmrc
+nvm use   # picks up the version from .nvmrc (or: fnm use)
 npm install
 npm run dev
 ```


### PR DESCRIPTION
`fnm` reads `.nvmrc` natively and is a common drop-in replacement for `nvm`. Added `(or: fnm use)` to the running-locally section so either works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)