### PR TITLE
fix: accept both dependabot actor login formats in auto-merge check

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -37,7 +37,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge if Dependabot PR
-        if: steps.pr.outputs.skip != 'true' && steps.pr.outputs.actor == 'dependabot[bot]'
+        if: >-
+          steps.pr.outputs.skip != 'true' &&
+          (steps.pr.outputs.actor == 'dependabot[bot]' ||
+           steps.pr.outputs.actor == 'app/dependabot')
         run: gh pr merge --squash --repo "$GITHUB_REPOSITORY" "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `dependabot-auto-merge.yml` merge step was never firing because it checked for actor `dependabot[bot]`, but `gh`'s GraphQL endpoint returns `app/dependabot`. All Dependabot PRs were silently skipped.

This is why all 10 current dependency PRs are still open despite CI passing weeks ago.

Accepts both login formats so the workflow works regardless of which GitHub API endpoint reports the actor.