### PR TITLE
fix: release on dependabot pushes to main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Dependabot PRs have been merging cleanly but not producing releases. The `auto-release` job had an explicit actor guard that skipped the whole job for `dependabot[bot]` pushes:

```yaml
if: github.actor != 'dependabot[bot]'
```

Removing that one line is all that's needed. Dependabot PRs never carry `version:major` or `version:minor` labels, so the existing label-check logic always falls through to `patch` — the right default.

`deploy.yml` already had no such guard, so GitHub Pages deploys were already running for dependabot pushes. This just closes the release gap.

**Validation:** YAML parses cleanly; the `-1/+0` diff is the only change.