### PR TITLE
fix: run deploy only after CI passes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 name: Deploy
 
+# Depends on ci.yml — only runs after CI passes on main.
 on:
   workflow_run:
     workflows: ["CI"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
 name: Deploy
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
 
 permissions:
@@ -16,6 +18,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
Switch `deploy.yml` from a `push` trigger to `workflow_run` so it only runs when CI completes successfully on main. Deploy used to race CI on every push; now it waits.

The `if: github.event.workflow_run.conclusion == 'success'` guard short-circuits the deploy job if CI fails, so a broken push won't trigger a deployment.

No changes to `ci.yml` or any other workflow. `dependabot-auto-merge.yml` already uses the same `workflow_run` pattern against `"CI"`, so nothing else is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)