### PR TITLE
fix: dispatch auto-release for Dependabot merges

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,6 +3,16 @@ name: Auto-release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to release (defaults to HEAD of main)"
+        required: false
+        type: string
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -19,7 +29,7 @@ jobs:
       - name: Get merged PR
         id: pr
         run: |
-          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number // empty')
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.sha || github.sha }}/pulls" --jq '.[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR found; will create patch release from commit."
           else
@@ -68,8 +78,8 @@ jobs:
           if [ -n "$PR_NUMBER" ]; then
             printf '%s\n\n%s\n\nPR: #%s\n' "$TITLE" "$BODY" "$PR_NUMBER" > notes.md
           else
-            COMMIT_MSG=$(git log -1 --format='%s' "${{ github.sha }}")
-            printf '%s\n\nCommit: %s\n' "$COMMIT_MSG" "${{ github.sha }}" > notes.md
+            COMMIT_MSG=$(git log -1 --format='%s' "${{ inputs.sha || github.sha }}")
+            printf '%s\n\nCommit: %s\n' "$COMMIT_MSG" "${{ inputs.sha || github.sha }}" > notes.md
           fi
           gh release create "$TAG" \
             --title "$TAG" \

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get merged PR
         id: pr
         run: |
-          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.sha || github.sha }}/pulls" --jq '.[0].number // empty')
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.inputs.sha || github.sha }}/pulls" --jq '.[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR found; will create patch release from commit."
           else
@@ -78,8 +78,8 @@ jobs:
           if [ -n "$PR_NUMBER" ]; then
             printf '%s\n\n%s\n\nPR: #%s\n' "$TITLE" "$BODY" "$PR_NUMBER" > notes.md
           else
-            COMMIT_MSG=$(git log -1 --format='%s' "${{ inputs.sha || github.sha }}")
-            printf '%s\n\nCommit: %s\n' "$COMMIT_MSG" "${{ inputs.sha || github.sha }}" > notes.md
+            COMMIT_MSG=$(git log -1 --format='%s' "${{ github.event.inputs.sha || github.sha }}")
+            printf '%s\n\nCommit: %s\n' "$COMMIT_MSG" "${{ github.event.inputs.sha || github.sha }}" > notes.md
           fi
           gh release create "$TAG" \
             --title "$TAG" \
@@ -88,7 +88,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
-          RELEASE_SHA: ${{ inputs.sha || github.sha }}
+          RELEASE_SHA: ${{ github.event.inputs.sha || github.sha }}
           TITLE: ${{ steps.pr.outputs.title }}
           BODY: ${{ steps.pr.outputs.body }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -83,10 +83,12 @@ jobs:
           fi
           gh release create "$TAG" \
             --title "$TAG" \
+            --target "$RELEASE_SHA" \
             --notes-file notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_SHA: ${{ inputs.sha || github.sha }}
           TITLE: ${{ steps.pr.outputs.title }}
           BODY: ${{ steps.pr.outputs.body }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -54,6 +54,10 @@ jobs:
            steps.pr.outputs.actor == 'app/dependabot')
         run: |
           MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json mergeCommit --jq '.mergeCommit.oid')
+          if [ -z "$MERGE_SHA" ]; then
+            echo "Could not resolve merge commit SHA for PR #$PR_NUMBER; skipping auto-release dispatch."
+            exit 1
+          fi
           gh workflow run auto-release.yml --repo "$GITHUB_REPOSITORY" --ref main -f sha="$MERGE_SHA"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -42,6 +43,18 @@ jobs:
           (steps.pr.outputs.actor == 'dependabot[bot]' ||
            steps.pr.outputs.actor == 'app/dependabot')
         run: gh pr merge --squash --repo "$GITHUB_REPOSITORY" "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+
+      - name: Dispatch auto-release for merged Dependabot PR
+        if: >-
+          steps.pr.outputs.skip != 'true' &&
+          (steps.pr.outputs.actor == 'dependabot[bot]' ||
+           steps.pr.outputs.actor == 'app/dependabot')
+        run: |
+          MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json mergeCommit --jq '.mergeCommit.oid')
+          gh workflow run auto-release.yml --repo "$GITHUB_REPOSITORY" --ref main -f sha="$MERGE_SHA"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json mergeCommit --jq '.mergeCommit.oid')
           if [ -z "$MERGE_SHA" ]; then
-            echo "Could not resolve merge commit SHA for PR #$PR_NUMBER; skipping auto-release dispatch."
+            echo "Error: could not resolve merge commit SHA for PR #$PR_NUMBER — auto-release dispatch failed."
             exit 1
           fi
           gh workflow run auto-release.yml --repo "$GITHUB_REPOSITORY" --ref main -f sha="$MERGE_SHA"


### PR DESCRIPTION
## Summary

`auto-release.yml` triggers on `push` to `main`, but Dependabot merges are performed by `dependabot-auto-merge.yml` using `GITHUB_TOKEN`. GitHub explicitly prevents push events made by `GITHUB_TOKEN` from triggering other workflow runs — so `auto-release` never fires and no releases are created.

`workflow_dispatch` is one of the two exceptions to this restriction. This PR:

1. Adds a `workflow_dispatch` trigger (with an optional `sha` input) to `auto-release.yml` so it can be called explicitly
2. Adds a `concurrency` group to `auto-release.yml` to prevent duplicate tag collisions if two dispatches race
3. Adds a "Dispatch auto-release" step to `dependabot-auto-merge.yml` that fires after a successful squash merge, passing the merge commit SHA directly to avoid any race with concurrent activity on `main`
4. Adds `actions: write` permission to `dependabot-auto-merge.yml` (required for `gh workflow run` to succeed)

#### Flow after this change

CI passes → `dependabot-auto-merge` merges PR → resolves merge commit SHA → dispatches `auto-release` with that SHA → patch release created

Human-authored merges continue to work as before via the `push` trigger.

## Testing

No way to trigger a real Dependabot merge in a test environment, but I validated:

- YAML syntax is well-formed (no tab indentation, correct structure)
- `${{ inputs.sha || github.sha }}` is used consistently — both in the PR lookup and the commit message fallback
- The dispatch step gates on the same `if:` condition as the merge step, so it only fires when a Dependabot merge actually happened
- `gh pr view ... --json mergeCommit --jq '.mergeCommit.oid'` is the correct way to get the squash merge commit SHA after `gh pr merge` completes

Related: #70, #71 (prior attempts at this fix that handled the human-merge path but not the auto-merge path)