### PR TITLE
feat: dedupe shared helpers, expand test coverage, and harden persistence

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,10 +12,6 @@ export default tseslint.config(
       // typescript-eslint flags unused vars; let tsc handle that instead so we
       // don't duplicate the noUnusedLocals / noUnusedParameters tsc checks.
       '@typescript-eslint/no-unused-vars': 'off',
-      // Advisory rule about calling setState inside effects. The useColumnOrder
-      // hook intentionally uses this pattern to sync an ordered list of IDs
-      // when participants are added/removed; turning it off project-wide.
-      'react-hooks/set-state-in-effect': 'off',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
-    "test": "tsx src/lib/versionedStore.test.ts && tsx src/utils/calculate.test.ts && tsx src/utils/format.test.ts"
+    "test": "tsx src/lib/versionedStore.test.ts && tsx src/utils/calculate.test.ts && tsx src/utils/format.test.ts && tsx src/hooks/useBillSplit.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
-    "test": "tsx src/lib/versionedStore.test.ts && tsx src/utils/calculate.test.ts"
+    "test": "tsx src/lib/versionedStore.test.ts && tsx src/utils/calculate.test.ts && tsx src/utils/format.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { ConfirmModal } from './components/ConfirmModal'
 export function App() {
   const {
     state,
+    saveFailed,
     addParticipant,
     removeParticipant,
     renameParticipant,
@@ -29,6 +30,7 @@ export function App() {
     setSinglePayer,
     setAmountPaid,
     reset,
+    dismissSaveWarning,
   } = useBillSplit()
 
   const { columnOrder, setColumnOrder, orderedParticipants } = useColumnOrder(state.participants)
@@ -45,6 +47,21 @@ export function App() {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      {saveFailed && (
+        <div
+          role="status"
+          className="flex items-center justify-between gap-3 bg-amber-50 border-b border-amber-200 px-4 py-2 text-sm text-amber-800"
+        >
+          <span>Changes can't be saved — private browsing or storage is full.</span>
+          <button
+            onClick={dismissSaveWarning}
+            aria-label="Dismiss"
+            className="text-amber-600 hover:text-amber-800 focus:outline-none font-medium"
+          >
+            ×
+          </button>
+        </div>
+      )}
       <div className="max-w-4xl mx-auto px-4 py-8">
         {/* Header */}
         <div className="flex items-center justify-between mb-8">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,9 +36,6 @@ export function App() {
   const { columnOrder, setColumnOrder, orderedParticipants } = useColumnOrder(state.participants)
   const [showResetModal, setShowResetModal] = useState(false)
 
-  // Recalculate on every render. The calculation is fast enough that memoizing
-  // by individual field is not necessary, but useMemo avoids recomputing when
-  // an unrelated parent re-renders.
   const breakdown = useMemo(() => calculateBreakdown(state), [state])
   const transactions = useMemo(
     () => calculateSettlement(state, breakdown),

--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -152,7 +152,6 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
     onUpdateItem({ ...item, assignedTo: next })
   }
 
-
   const isLastRow = (item: Item) => item === items[items.length - 1]
 
   return (

--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -270,7 +270,7 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
                                 {assigned && <CheckIcon />}
                               </span>
                               <span className="text-xs text-gray-600 tabular-nums">
-                                {share > 0 ? fmt(share) : <span className="text-gray-300">—</span>}
+                                {share > 0 ? formatAmount(share) : <span className="text-gray-300">—</span>}
                               </span>
                             </label>
                           )}
@@ -365,7 +365,7 @@ function ColumnDragOverlay({
               {assigned && <CheckIcon />}
             </span>
             <span className="text-xs text-gray-600 tabular-nums">
-              {share > 0 ? fmt(share) : <span className="text-gray-300">—</span>}
+              {share > 0 ? formatAmount(share) : <span className="text-gray-300">—</span>}
             </span>
           </div>
         )
@@ -453,7 +453,6 @@ function SortableItemRow({
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-const fmt = formatAmount
 
 function CheckIcon() {
   return (

--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -130,7 +130,7 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
 
   function isAssignedToAll(item: Item): boolean {
     if (item.assignedTo === null) return true
-    return allIds.length > 0 && allIds.every(id => item.assignedTo!.includes(id))
+    return allIds.length > 0 && allIds.every(id => (item.assignedTo ?? []).includes(id))
   }
 
   function toggleAllAssigned(item: Item) {

--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -21,6 +21,7 @@ import { CSS } from '@dnd-kit/utilities'
 import type { Item, Participant } from '../types'
 import { isValidPrice } from '../utils/calculate'
 import { formatAmount } from '../utils/format'
+import { NAME_MAX_LENGTH } from '../constants'
 
 function isParticipantAssigned(item: Item, participantId: string): boolean {
   if (item.assignedTo === null) return true
@@ -190,6 +191,7 @@ export function ItemsTable({ participants, items, columnOrder, onUpdateItem, onR
                         onChange={e => onUpdateItem({ ...item, name: e.target.value })}
                         placeholder={blank ? 'Description' : ''}
                         aria-label="Item description"
+                        maxLength={NAME_MAX_LENGTH}
                         className="w-full bg-transparent border-0 border-b border-dashed border-gray-300 focus:border-gray-500 focus:outline-none py-0.5 placeholder-gray-300 text-gray-800"
                       />
                     </td>

--- a/src/components/ParticipantSection.tsx
+++ b/src/components/ParticipantSection.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react'
 import type { Participant } from '../types'
+import { NAME_MAX_LENGTH } from '../constants'
 
 interface Props {
   participants: Participant[]
@@ -64,6 +65,7 @@ export function ParticipantSection({ participants, onAdd, onRemove, onRename }: 
             onKeyDown={handleKeyDown}
             placeholder="Add participant"
             aria-label="New participant name"
+            maxLength={NAME_MAX_LENGTH}
             className="border border-gray-300 rounded-full px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent min-w-[140px]"
           />
           <button
@@ -133,6 +135,7 @@ function ParticipantChip({ participant, onRemove, onRename }: ChipProps) {
             onKeyDown={handleKeyDown}
             onBlur={commit}
             aria-label={`Rename ${participant.name}`}
+            maxLength={NAME_MAX_LENGTH}
             className="border border-teal-400 rounded-full px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500 min-w-[100px]"
           />
           {error && (

--- a/src/components/ParticipantSection.tsx
+++ b/src/components/ParticipantSection.tsx
@@ -10,9 +10,8 @@ interface Props {
 }
 
 /**
- * Participant management is intentionally isolated in this component so the
- * source of participant data (freeform text today, user profile tomorrow) can
- * be swapped without touching the rest of the app.
+ * Participant management is isolated so the data source can change without
+ * touching the rest of the app.
  */
 export function ParticipantSection({ participants, onAdd, onRemove, onRename }: Props) {
   const [newName, setNewName] = useState('')

--- a/src/components/PayerSection.tsx
+++ b/src/components/PayerSection.tsx
@@ -117,7 +117,7 @@ export function PayerSection({
 
           {mismatch && (
             <p role="status" className="text-xs text-amber-600 mt-1">
-              Total paid ({fmt(totalPaid)}) doesn't match the grand total ({fmt(grandTotal)}).
+              Total paid ({formatMoney(totalPaid)}) doesn't match the grand total ({formatMoney(grandTotal)}).
               Settlement will reflect the difference.
             </p>
           )}
@@ -127,4 +127,3 @@ export function PayerSection({
   )
 }
 
-const fmt = formatMoney

--- a/src/components/PayerSection.tsx
+++ b/src/components/PayerSection.tsx
@@ -1,5 +1,5 @@
 import type { BillState, Participant, PayerMode } from '../types'
-import { isValidPrice } from '../utils/calculate'
+import { isValidPrice, parsePaidAmount } from '../utils/calculate'
 import type { BillBreakdown } from '../utils/calculate'
 import { formatMoney } from '../utils/format'
 
@@ -39,10 +39,7 @@ export function PayerSection({
   // Soft warning for multiple payer mode when amounts don't add up
   const totalPaid =
     payerMode === 'multiple'
-      ? participants.reduce((sum, p) => {
-          const val = Number(amountPaid[p.id] ?? '')
-          return sum + (isNaN(val) ? 0 : val)
-        }, 0)
+      ? participants.reduce((sum, p) => sum + parsePaidAmount(amountPaid[p.id]), 0)
       : grandTotal
 
   const mismatch =

--- a/src/components/SummarySection.tsx
+++ b/src/components/SummarySection.tsx
@@ -21,9 +21,7 @@ interface Props {
  * On narrow screens (below sm breakpoint) each participant is rendered as
  * a stacked card instead of a column in the table.
  *
- * This is intentionally display-only; all interactive inputs live in the
- * sections above. Rendering it separately keeps the component boundary clear
- * and makes it easy to extract into an export/print view later.
+ * Display-only; all interactive inputs live in the sections above.
  */
 export function SummarySection({ orderedParticipants, additionalFees, state, breakdown }: Props) {
   const isMobile = useIsMobile()

--- a/src/components/SummarySection.tsx
+++ b/src/components/SummarySection.tsx
@@ -78,7 +78,7 @@ export function SummarySection({ orderedParticipants, additionalFees, state, bre
               })}
               <div className="flex justify-between border-t border-gray-300 mt-2 pt-2 font-semibold text-gray-800">
                 <span>Total</span>
-                <span className="tabular-nums">{fmt(grandTotal)}</span>
+                <span className="tabular-nums">{formatAmount(grandTotal)}</span>
               </div>
             </div>
           )
@@ -152,11 +152,11 @@ export function SummarySection({ orderedParticipants, additionalFees, state, bre
           <tr className="border-t-2 border-gray-300 font-semibold">
             <td className="py-2 pr-3 text-gray-800">Grand total</td>
             <td className="py-2 px-2 text-right text-gray-800 tabular-nums">
-              {fmt(breakdown.totalGrandTotal)}
+              {formatAmount(breakdown.totalGrandTotal)}
             </td>
             {orderedParticipants.map(p => (
               <td key={p.id} className="py-2 px-2 text-right text-gray-800 tabular-nums">
-                {fmt(perPersonValue(p.id, 'grandTotal'))}
+                {formatAmount(perPersonValue(p.id, 'grandTotal'))}
               </td>
             ))}
           </tr>
@@ -181,7 +181,7 @@ function CardRow({
   return (
     <div className={`flex justify-between py-0.5 text-xs ${colorClass}`}>
       <span>{label}</span>
-      <span className="tabular-nums">{fmt(value)}</span>
+      <span className="tabular-nums">{formatAmount(value)}</span>
     </div>
   )
 }
@@ -203,14 +203,13 @@ function SummaryRow({
   return (
     <tr className="border-b border-gray-100">
       <td className={`py-1.5 pr-3 ${colorClass} text-xs`}>{label}</td>
-      <td className={`py-1.5 px-2 text-right tabular-nums ${colorClass}`}>{fmt(total)}</td>
+      <td className={`py-1.5 px-2 text-right tabular-nums ${colorClass}`}>{formatAmount(total)}</td>
       {values.map((v, i) => (
         <td key={i} className={`py-1.5 px-2 text-right tabular-nums ${colorClass}`}>
-          {fmt(v)}
+          {formatAmount(v)}
         </td>
       ))}
     </tr>
   )
 }
 
-const fmt = formatAmount

--- a/src/components/TaxTipSection.tsx
+++ b/src/components/TaxTipSection.tsx
@@ -1,6 +1,6 @@
 import { useId } from 'react'
 import type { AdditionalFee, FeesBase } from '../types'
-import { getAmountEquivalent, getTotalFeeBase, isValidAmount } from '../utils/calculate'
+import { getAmountEquivalent, getTotalFeeBase, isValidAmount, splitAmountInput } from '../utils/calculate'
 
 interface Props {
   tax: string
@@ -84,7 +84,7 @@ export function TaxTipSection({
         <IncludeTaxToggle
           base={tipBase}
           onChange={onSetTipBase}
-          disabled={!tip.trim().endsWith('%')}
+          disabled={!splitAmountInput(tip).isPercent}
         />
         {tipInvalid && (
           <span role="alert" className="text-xs text-red-600">Invalid amount</span>
@@ -135,7 +135,7 @@ function FeeRow({
   // Detect whether the current amount is a discount (negative) so we can
   // label it clearly alongside any visual distinction.
   const trimmedAmount = fee.amount.trim()
-  const numAmount = Number(trimmedAmount.endsWith('%') ? trimmedAmount.slice(0, -1) : trimmedAmount)
+  const numAmount = Number(splitAmountInput(trimmedAmount).numeric)
   const isDiscount = trimmedAmount.startsWith('-') || (!isNaN(numAmount) && numAmount < 0)
 
   function toggleSign() {
@@ -185,7 +185,7 @@ function FeeRow({
       <IncludeTaxToggle
         base={fee.base}
         onChange={b => onChange({ ...fee, base: b })}
-        disabled={!fee.amount.trim().endsWith('%')}
+        disabled={!splitAmountInput(fee.amount).isPercent}
       />
       {amountInvalid && (
         <span role="alert" className="text-xs text-red-600">Invalid amount</span>
@@ -220,16 +220,15 @@ function AmountInput({
 }) {
   // Parse into numeric portion and percent flag.
   // A trailing "%" in the stored value means percent mode is on.
-  const trimmed = value.trim()
-  const isPercent = trimmed.endsWith('%')
-  const numeric = isPercent ? trimmed.slice(0, -1) : trimmed
+  const { isPercent, numeric } = splitAmountInput(value)
   const equivalent = !invalid && base !== undefined ? getAmountEquivalent(value, base) : null
 
   function handleInputChange(raw: string) {
     // "%" typed directly acts as a toggle: turns percent mode on if off,
     // off if already on. This mirrors the behavior of the % button.
-    if (raw.endsWith('%')) {
-      onChange(raw.slice(0, -1) + (isPercent ? '' : '%'))
+    const { isPercent: rawIsPercent, numeric: rawNumeric } = splitAmountInput(raw)
+    if (rawIsPercent) {
+      onChange(rawNumeric + (isPercent ? '' : '%'))
     } else {
       onChange(raw + (isPercent ? '%' : ''))
     }

--- a/src/components/TaxTipSection.tsx
+++ b/src/components/TaxTipSection.tsx
@@ -1,6 +1,7 @@
 import { useId } from 'react'
 import type { AdditionalFee, FeesBase } from '../types'
 import { getAmountEquivalent, getTotalFeeBase, isValidAmount, splitAmountInput } from '../utils/calculate'
+import { NAME_MAX_LENGTH } from '../constants'
 
 interface Props {
   tax: string
@@ -159,6 +160,7 @@ function FeeRow({
         onChange={e => onChange({ ...fee, name: e.target.value })}
         placeholder="Name"
         aria-label="Fee name"
+        maxLength={NAME_MAX_LENGTH}
         className="border-b border-dashed border-gray-300 focus:border-gray-500 focus:outline-none bg-transparent py-0.5 w-28 text-gray-800 placeholder-gray-300"
       />
       <AmountInput

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const NAME_MAX_LENGTH = 60

--- a/src/hooks/useBillSplit.test.ts
+++ b/src/hooks/useBillSplit.test.ts
@@ -1,0 +1,96 @@
+// Pure-function tests for isBillState.
+// Run with: npm test
+
+import { isBillState } from './useBillSplit'
+import { test, assert, summary } from '../test/harness'
+
+console.log('\nisBillState')
+
+const validState = {
+  participants: [{ id: 'a', name: 'Alice' }],
+  items: [{ id: 'i1', name: 'Tacos', price: '10.00', assignedTo: null }],
+  tax: '8%',
+  tip: '18%',
+  tipBase: 'pre-tax',
+  additionalFees: [{ id: 'f1', name: 'Service', amount: '2', base: 'pre-tax' }],
+  payerMode: 'single',
+  singlePayerId: 'a',
+  amountPaid: {},
+}
+
+test('valid fully-populated state returns true', () => {
+  assert(isBillState(validState), 'valid state accepted')
+})
+
+test('valid state with empty arrays returns true', () => {
+  assert(isBillState({ ...validState, participants: [], items: [], additionalFees: [] }), 'empty arrays ok')
+})
+
+test('null returns false', () => {
+  assert(!isBillState(null), 'null rejected')
+})
+
+test('non-object returns false', () => {
+  assert(!isBillState('string'), 'string rejected')
+  assert(!isBillState(42), 'number rejected')
+})
+
+test('missing top-level field returns false', () => {
+  const { tax: _tax, ...noTax } = validState
+  assert(!isBillState(noTax), 'missing tax rejected')
+})
+
+test('items: [null] returns false', () => {
+  assert(!isBillState({ ...validState, items: [null] }), 'null item rejected')
+})
+
+test('items: [{ garbage: 1 }] returns false', () => {
+  assert(!isBillState({ ...validState, items: [{ garbage: 1 }] }), 'garbage item rejected')
+})
+
+test('item with non-string price returns false', () => {
+  const badItem = { id: 'i1', name: 'x', price: 10, assignedTo: null }
+  assert(!isBillState({ ...validState, items: [badItem] }), 'numeric price rejected')
+})
+
+test('item with string assignedTo returns false', () => {
+  const badItem = { id: 'i1', name: 'x', price: '10', assignedTo: 'alice' }
+  assert(!isBillState({ ...validState, items: [badItem] }), 'string assignedTo rejected')
+})
+
+test('item with boolean taxable value is valid', () => {
+  const itemWithTaxable = { id: 'i1', name: 'x', price: '10', assignedTo: null, taxable: false }
+  assert(isBillState({ ...validState, items: [itemWithTaxable] }), 'boolean taxable accepted')
+})
+
+test('item with non-boolean taxable returns false', () => {
+  const badItem = { id: 'i1', name: 'x', price: '10', assignedTo: null, taxable: 'yes' }
+  assert(!isBillState({ ...validState, items: [badItem] }), 'string taxable rejected')
+})
+
+test('participants: [null] returns false', () => {
+  assert(!isBillState({ ...validState, participants: [null] }), 'null participant rejected')
+})
+
+test('participant missing id returns false', () => {
+  assert(!isBillState({ ...validState, participants: [{ name: 'Alice' }] }), 'participant without id rejected')
+})
+
+test('additionalFees: [null] returns false', () => {
+  assert(!isBillState({ ...validState, additionalFees: [null] }), 'null fee rejected')
+})
+
+test('fee with invalid base returns false', () => {
+  const badFee = { id: 'f1', name: 'x', amount: '2', base: 'with-tax' }
+  assert(!isBillState({ ...validState, additionalFees: [badFee] }), 'invalid fee base rejected')
+})
+
+test('invalid tipBase returns false', () => {
+  assert(!isBillState({ ...validState, tipBase: 'with-tax' }), 'invalid tipBase rejected')
+})
+
+test('invalid payerMode returns false', () => {
+  assert(!isBillState({ ...validState, payerMode: 'group' }), 'invalid payerMode rejected')
+})
+
+summary()

--- a/src/hooks/useBillSplit.ts
+++ b/src/hooks/useBillSplit.ts
@@ -20,10 +20,27 @@ const DEFAULT_STATE: BillState = {
 
 // ─── Persistence ──────────────────────────────────────────────────────────────
 
+function isBillState(v: unknown): v is BillState {
+  if (typeof v !== 'object' || v === null) return false
+  const s = v as Record<string, unknown>
+  return (
+    Array.isArray(s.participants) &&
+    Array.isArray(s.items) &&
+    typeof s.tax === 'string' &&
+    typeof s.tip === 'string' &&
+    (s.tipBase === 'pre-tax' || s.tipBase === 'post-tax') &&
+    Array.isArray(s.additionalFees) &&
+    (s.payerMode === 'single' || s.payerMode === 'multiple') &&
+    typeof s.singlePayerId === 'string' &&
+    typeof s.amountPaid === 'object' && s.amountPaid !== null && !Array.isArray(s.amountPaid)
+  )
+}
+
 const billStore = makeVersionedStore<BillState>(
   'bill-split:v2',
   [['bill-split:v1', migrateV1toBillV2]],
   DEFAULT_STATE,
+  isBillState,
 )
 
 function loadState(): BillState {

--- a/src/hooks/useBillSplit.ts
+++ b/src/hooks/useBillSplit.ts
@@ -210,6 +210,7 @@ export function useBillSplit() {
   // Persist to localStorage on every state change
   useEffect(() => {
     const ok = billStore.save(state)
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSaveFailed(!ok)
   }, [state])
 

--- a/src/hooks/useBillSplit.ts
+++ b/src/hooks/useBillSplit.ts
@@ -20,16 +20,49 @@ const DEFAULT_STATE: BillState = {
 
 // ─── Persistence ──────────────────────────────────────────────────────────────
 
-function isBillState(v: unknown): v is BillState {
+function isParticipant(v: unknown): boolean {
+  if (typeof v !== 'object' || v === null) return false
+  const p = v as Record<string, unknown>
+  return typeof p.id === 'string' && typeof p.name === 'string'
+}
+
+function isItem(v: unknown): boolean {
+  if (typeof v !== 'object' || v === null) return false
+  const item = v as Record<string, unknown>
+  return (
+    typeof item.id === 'string' &&
+    typeof item.name === 'string' &&
+    typeof item.price === 'string' &&
+    (item.assignedTo === null ||
+      (Array.isArray(item.assignedTo) && (item.assignedTo as unknown[]).every(id => typeof id === 'string'))) &&
+    (item.taxable === undefined || typeof item.taxable === 'boolean')
+  )
+}
+
+function isAdditionalFee(v: unknown): boolean {
+  if (typeof v !== 'object' || v === null) return false
+  const fee = v as Record<string, unknown>
+  return (
+    typeof fee.id === 'string' &&
+    typeof fee.name === 'string' &&
+    typeof fee.amount === 'string' &&
+    (fee.base === 'pre-tax' || fee.base === 'post-tax')
+  )
+}
+
+export function isBillState(v: unknown): v is BillState {
   if (typeof v !== 'object' || v === null) return false
   const s = v as Record<string, unknown>
   return (
     Array.isArray(s.participants) &&
+    s.participants.every(isParticipant) &&
     Array.isArray(s.items) &&
+    s.items.every(isItem) &&
     typeof s.tax === 'string' &&
     typeof s.tip === 'string' &&
     (s.tipBase === 'pre-tax' || s.tipBase === 'post-tax') &&
     Array.isArray(s.additionalFees) &&
+    s.additionalFees.every(isAdditionalFee) &&
     (s.payerMode === 'single' || s.payerMode === 'multiple') &&
     typeof s.singlePayerId === 'string' &&
     typeof s.amountPaid === 'object' && s.amountPaid !== null && !Array.isArray(s.amountPaid)

--- a/src/hooks/useBillSplit.ts
+++ b/src/hooks/useBillSplit.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer } from 'react'
+import { useCallback, useEffect, useReducer, useState } from 'react'
 import { nanoid } from 'nanoid'
 import type { BillState, Item, AdditionalFee, FeesBase, PayerMode } from '../types'
 import { makeVersionedStore } from '../lib/versionedStore'
@@ -205,10 +205,12 @@ function reducer(state: BillState, action: Action): BillState {
 
 export function useBillSplit() {
   const [state, dispatch] = useReducer(reducer, undefined, loadState)
+  const [saveFailed, setSaveFailed] = useState(false)
 
   // Persist to localStorage on every state change
   useEffect(() => {
-    billStore.save(state)
+    const ok = billStore.save(state)
+    setSaveFailed(!ok)
   }, [state])
 
   const addParticipant = useCallback(
@@ -265,9 +267,11 @@ export function useBillSplit() {
       dispatch({ type: 'REORDER_ITEMS', fromIndex, toIndex }),
     [],
   )
+  const dismissSaveWarning = useCallback(() => setSaveFailed(false), [])
 
   return {
     state,
+    saveFailed,
     addParticipant,
     removeParticipant,
     renameParticipant,
@@ -284,5 +288,6 @@ export function useBillSplit() {
     setSinglePayer,
     setAmountPaid,
     reset,
+    dismissSaveWarning,
   }
 }

--- a/src/hooks/useColumnOrder.ts
+++ b/src/hooks/useColumnOrder.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import type { Participant } from '../types'
+import { readJSON, writeJSON } from '../lib/versionedStore'
 
 const COLUMN_ORDER_KEY = 'bill-split-column-order:v1'
 
@@ -16,20 +17,15 @@ export function useColumnOrder(participants: Participant[]): {
 } {
   const [columnOrder, setColumnOrder] = useState<string[]>(() => {
     const allIds = participants.map(p => p.id)
-    try {
-      const stored = localStorage.getItem(COLUMN_ORDER_KEY)
-      if (stored) {
-        const parsed = JSON.parse(stored) as unknown
-        if (Array.isArray(parsed)) {
-          // Deduplicate before filtering so corrupt/duplicate localStorage data
-          // can't produce duplicate columns.
-          const ids = [...new Set(parsed as string[])]
-          const filtered = ids.filter(id => allIds.includes(id))
-          const added = allIds.filter(id => !ids.includes(id))
-          return [...filtered, ...added]
-        }
-      }
-    } catch { /* ignore corrupt or blocked localStorage */ }
+    const parsed = readJSON(COLUMN_ORDER_KEY)
+    if (Array.isArray(parsed)) {
+      // Deduplicate before filtering so corrupt/duplicate localStorage data
+      // can't produce duplicate columns.
+      const ids = [...new Set(parsed as string[])]
+      const filtered = ids.filter(id => allIds.includes(id))
+      const added = allIds.filter(id => !ids.includes(id))
+      return [...filtered, ...added]
+    }
     return [...allIds]
   })
 
@@ -46,9 +42,7 @@ export function useColumnOrder(participants: Participant[]): {
 
   // Persist to localStorage
   useEffect(() => {
-    try {
-      localStorage.setItem(COLUMN_ORDER_KEY, JSON.stringify(columnOrder))
-    } catch { /* ignore quota-exceeded or private-browsing errors */ }
+    writeJSON(COLUMN_ORDER_KEY, columnOrder)
   }, [columnOrder])
 
   const participantMap = new Map(participants.map(p => [p.id, p]))

--- a/src/hooks/useColumnOrder.ts
+++ b/src/hooks/useColumnOrder.ts
@@ -31,6 +31,7 @@ export function useColumnOrder(participants: Participant[]): {
 
   // Sync when participants are added or removed
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setColumnOrder(prev => {
       const participantIds = participants.map(p => p.id)
       const filtered = prev.filter(id => participantIds.includes(id))

--- a/src/lib/versionedStore.test.ts
+++ b/src/lib/versionedStore.test.ts
@@ -137,6 +137,36 @@ test('second load after save returns saved value', () => {
   assertEqual(store.load(), { x: 55 }, 'round-trip')
 })
 
+test('validate: valid current key passes through unchanged', () => {
+  localStorage.setItem('key:v2', JSON.stringify({ x: 42 }))
+  const isValid = (v: unknown): v is { x: number } =>
+    typeof (v as Record<string, unknown>).x === 'number'
+  const store = makeVersionedStore<{ x: number }>('key:v2', [], { x: 0 }, isValid)
+  assertEqual(store.load(), { x: 42 }, 'valid value returned directly')
+})
+
+test('validate: invalid-shape current key falls back to fallback', () => {
+  localStorage.setItem('key:v2', JSON.stringify({ notX: 'wrong' }))
+  const isValid = (v: unknown): v is { x: number } =>
+    typeof (v as Record<string, unknown>).x === 'number'
+  const store = makeVersionedStore<{ x: number }>('key:v2', [], { x: -1 }, isValid)
+  assertEqual(store.load(), { x: -1 }, 'invalid shape falls back to fallback')
+})
+
+test('validate: invalid-shape current key falls back to migration when available', () => {
+  localStorage.setItem('key:v2', JSON.stringify({ notX: 'wrong' }))
+  localStorage.setItem('key:v1', JSON.stringify({ x: 7 }))
+  const isValid = (v: unknown): v is { x: number } =>
+    typeof (v as Record<string, unknown>).x === 'number'
+  const store = makeVersionedStore<{ x: number }>(
+    'key:v2',
+    [['key:v1', raw => raw as { x: number }]],
+    { x: -1 },
+    isValid,
+  )
+  assertEqual(store.load(), { x: 7 }, 'migrated value returned when current key fails validation')
+})
+
 test('migration succeeds and returns migrated value even when removeItem throws', () => {
   localStorage.setItem('key:v1', JSON.stringify({ x: 7 }))
   // Force removeItem to fail to verify the try/catch guard in versionedStore

--- a/src/lib/versionedStore.test.ts
+++ b/src/lib/versionedStore.test.ts
@@ -137,6 +137,19 @@ test('second load after save returns saved value', () => {
   assertEqual(store.load(), { x: 55 }, 'round-trip')
 })
 
+test('migration succeeds and returns migrated value even when removeItem throws', () => {
+  localStorage.setItem('key:v1', JSON.stringify({ x: 7 }))
+  // Force removeItem to fail to verify the try/catch guard in versionedStore
+  mockStorage.removeItem = () => { throw new Error('simulated removeItem failure') }
+  const store = makeVersionedStore<{ x: number; migrated: boolean }>(
+    'key:v2',
+    [['key:v1', raw => ({ ...(raw as { x: number }), migrated: true })]],
+    { x: 0, migrated: false },
+  )
+  const result = store.load()
+  assertEqual(result, { x: 7, migrated: true }, 'migrated value returned despite removeItem failure')
+})
+
 // ─── migrateV1toBillV2 fuzz tests ─────────────────────────────────────────────
 
 console.log('\nmigrateV1toBillV2 (fuzz)')
@@ -221,6 +234,44 @@ test('fuzz: missing items field produces empty items array', () => {
 test('fuzz: null payload fields do not crash migration', () => {
   const result = migrateV1toBillV2({ items: undefined, participants: undefined })
   assert(Array.isArray(result.items), 'items is array even when input items is undefined')
+})
+
+// ─── migrateV1toBillV2 validation tests ──────────────────────────────────────
+
+console.log('\nmigrateV1toBillV2 (validation)')
+
+function assertThrows(fn: () => unknown, label: string) {
+  let threw = false
+  try { fn() } catch { threw = true }
+  assert(threw, label)
+}
+
+test('throws when assignedTo is a string', () => {
+  assertThrows(
+    () => migrateV1toBillV2({ items: [{ id: 'x', name: 'x', price: '1.00', assignedTo: 'invalid' }] }),
+    'should throw for string assignedTo',
+  )
+})
+
+test('throws when assignedTo is a boolean', () => {
+  assertThrows(
+    () => migrateV1toBillV2({ items: [{ id: 'x', name: 'x', price: '1.00', assignedTo: true }] }),
+    'should throw for boolean assignedTo',
+  )
+})
+
+test('throws when assignedTo is a plain object', () => {
+  assertThrows(
+    () => migrateV1toBillV2({ items: [{ id: 'x', name: 'x', price: '1.00', assignedTo: { ids: [] } }] }),
+    'should throw for object assignedTo',
+  )
+})
+
+test('throws when price is a number instead of string', () => {
+  assertThrows(
+    () => migrateV1toBillV2({ items: [{ id: 'x', name: 'x', price: 9.99, assignedTo: null }] }),
+    'should throw for numeric price',
+  )
 })
 
 // ─── Summary ──────────────────────────────────────────────────────────────────

--- a/src/lib/versionedStore.test.ts
+++ b/src/lib/versionedStore.test.ts
@@ -137,6 +137,19 @@ test('second load after save returns saved value', () => {
   assertEqual(store.load(), { x: 55 }, 'round-trip')
 })
 
+test('save returns true on success', () => {
+  const store = makeVersionedStore<{ x: number }>('key:v2', [], { x: 0 })
+  const result = store.save({ x: 1 })
+  assert(result === true, 'save returns true when setItem succeeds')
+})
+
+test('save returns false when setItem throws (simulated quota exceeded)', () => {
+  const store = makeVersionedStore<{ x: number }>('key:v2', [], { x: 0 })
+  mockStorage.setItem = () => { throw new DOMException('QuotaExceededError') }
+  const result = store.save({ x: 99 })
+  assert(result === false, 'save returns false when setItem throws')
+})
+
 test('validate: valid current key passes through unchanged', () => {
   localStorage.setItem('key:v2', JSON.stringify({ x: 42 }))
   const isValid = (v: unknown): v is { x: number } =>

--- a/src/lib/versionedStore.test.ts
+++ b/src/lib/versionedStore.test.ts
@@ -6,6 +6,7 @@
 
 import { makeVersionedStore } from './versionedStore'
 import { migrateV1toBillV2 } from './billMigrations'
+import { test as baseTest, assert, assertEqual, summary } from '../test/harness'
 
 // ─── localStorage mock ────────────────────────────────────────────────────────
 
@@ -33,32 +34,9 @@ function resetStorage() {
   mockStorage = makeMockStorage()
 }
 
-// ─── Test harness ─────────────────────────────────────────────────────────────
-
-let passed = 0
-let failed = 0
-
+// Wrap the shared test() to reset storage before each case.
 function test(name: string, fn: () => void) {
-  resetStorage()
-  try {
-    fn()
-    console.log(`  ✓ ${name}`)
-    passed++
-  } catch (e) {
-    console.error(`  ✗ ${name}`)
-    console.error(`    ${e instanceof Error ? e.message : e}`)
-    failed++
-  }
-}
-
-function assert(condition: boolean, message: string): asserts condition {
-  if (!condition) throw new Error(message)
-}
-
-function assertEqual<T>(actual: T, expected: T, label: string) {
-  const a = JSON.stringify(actual)
-  const b = JSON.stringify(expected)
-  assert(a === b, `${label}\n    expected: ${b}\n    actual:   ${a}`)
+  baseTest(name, () => { resetStorage(); fn() })
 }
 
 // ─── makeVersionedStore tests ─────────────────────────────────────────────────
@@ -247,5 +225,4 @@ test('fuzz: null payload fields do not crash migration', () => {
 
 // ─── Summary ──────────────────────────────────────────────────────────────────
 
-console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`)
-if (failed > 0) process.exit(1)
+summary()

--- a/src/lib/versionedStore.ts
+++ b/src/lib/versionedStore.ts
@@ -17,13 +17,19 @@ export function makeVersionedStore<T>(
   currentKey: string,
   migrations: [oldKey: string, migrate: Migration<T>][],
   fallback: T,
+  validate?: (v: unknown) => v is T,
 ): VersionedStore<T> {
   return {
     load(): T {
       // Try the current key first.
       try {
         const raw = localStorage.getItem(currentKey)
-        if (raw !== null) return JSON.parse(raw) as T
+        if (raw !== null) {
+          const parsed: unknown = JSON.parse(raw)
+          // If a validator is supplied and the parsed value fails it, fall
+          // through to migrations rather than returning malformed state.
+          if (!validate || validate(parsed)) return parsed as T
+        }
       } catch {
         // Corrupt JSON in the current key — fall through to migrations.
       }

--- a/src/lib/versionedStore.ts
+++ b/src/lib/versionedStore.ts
@@ -10,7 +10,7 @@ type Migration<T> = (raw: unknown) => T
 
 interface VersionedStore<T> {
   load: () => T
-  save: (value: T) => void
+  save: (value: T) => boolean
 }
 
 /** Read and JSON-parse a localStorage key. Returns null if absent, blocked, or corrupt. */
@@ -69,8 +69,8 @@ export function makeVersionedStore<T>(
       return fallback
     },
 
-    save(value: T): void {
-      writeJSON(currentKey, value)
+    save(value: T): boolean {
+      return writeJSON(currentKey, value)
     },
   }
 }

--- a/src/lib/versionedStore.ts
+++ b/src/lib/versionedStore.ts
@@ -13,6 +13,26 @@ interface VersionedStore<T> {
   save: (value: T) => void
 }
 
+/** Read and JSON-parse a localStorage key. Returns null if absent, blocked, or corrupt. */
+export function readJSON(key: string): unknown {
+  try {
+    const raw = localStorage.getItem(key)
+    return raw !== null ? JSON.parse(raw) as unknown : null
+  } catch {
+    return null
+  }
+}
+
+/** JSON-serialize and write a value to localStorage. Returns true on success. */
+export function writeJSON(key: string, value: unknown): boolean {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function makeVersionedStore<T>(
   currentKey: string,
   migrations: [oldKey: string, migrate: Migration<T>][],
@@ -22,38 +42,27 @@ export function makeVersionedStore<T>(
   return {
     load(): T {
       // Try the current key first.
-      try {
-        const raw = localStorage.getItem(currentKey)
-        if (raw !== null) {
-          const parsed: unknown = JSON.parse(raw)
-          // If a validator is supplied and the parsed value fails it, fall
-          // through to migrations rather than returning malformed state.
-          if (!validate || validate(parsed)) return parsed as T
-        }
-      } catch {
-        // Corrupt JSON in the current key — fall through to migrations.
+      const current = readJSON(currentKey)
+      if (current !== null) {
+        // If a validator is supplied and the parsed value fails it, fall
+        // through to migrations rather than returning malformed state.
+        if (!validate || validate(current)) return current as T
       }
 
       // Walk migrations in order (most-recent old key first).
       for (const [oldKey, migrate] of migrations) {
-        let raw: string | null
-        try {
-          raw = localStorage.getItem(oldKey)
-        } catch {
-          // Storage blocked (e.g. SecurityError) — skip this key.
-          continue
-        }
+        const raw = readJSON(oldKey)
         if (raw === null) continue
 
         try {
-          const migrated = migrate(JSON.parse(raw))
-          localStorage.setItem(currentKey, JSON.stringify(migrated))
+          const migrated = migrate(raw)
+          writeJSON(currentKey, migrated)
           // Best-effort cleanup: a removeItem failure must not suppress the
           // migrated value that was already written to the current key.
           try { localStorage.removeItem(oldKey) } catch { /* ignore */ }
           return migrated
         } catch {
-          // Migration or serialization failed — try the next entry.
+          // Migration failed — try the next entry.
         }
       }
 
@@ -61,11 +70,7 @@ export function makeVersionedStore<T>(
     },
 
     save(value: T): void {
-      try {
-        localStorage.setItem(currentKey, JSON.stringify(value))
-      } catch {
-        // Storage quota exceeded or private browsing — degrade silently.
-      }
+      writeJSON(currentKey, value)
     },
   }
 }

--- a/src/test/harness.ts
+++ b/src/test/harness.ts
@@ -1,0 +1,32 @@
+// Shared test harness for the tsx-based test runner.
+// Each test file imports these and calls summary() at the end.
+
+let passed = 0
+let failed = 0
+
+export function test(name: string, fn: () => void) {
+  try {
+    fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (e) {
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${e instanceof Error ? e.message : e}`)
+    failed++
+  }
+}
+
+export function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new Error(message)
+}
+
+export function assertEqual<T>(actual: T, expected: T, label: string) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a !== b) throw new Error(`${label}\n    expected: ${b}\n    actual:   ${a}`)
+}
+
+export function summary() {
+  console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`)
+  if (failed > 0) process.exit(1)
+}

--- a/src/utils/calculate.test.ts
+++ b/src/utils/calculate.test.ts
@@ -530,7 +530,7 @@ test('additional fee on post-tax base', () => {
   assertEqual(bd.totalAdditionalFees[0], 1.1, '10% of $11 post-tax = $1.10')
 })
 
-test('percentage fee when pool base is 0 splits evenly', () => {
+test('flat fee when pool base is 0 splits evenly', () => {
   // No items → subtotal = 0, fee base = 0, distributeProportionally falls back to even split
   const s = state({
     participants: [p('A'), p('B')],

--- a/src/utils/calculate.test.ts
+++ b/src/utils/calculate.test.ts
@@ -4,6 +4,9 @@
 import {
   getAmountEquivalent,
   parseAmount,
+  isValidAmount,
+  isValidPrice,
+  getTotalFeeBase,
   reconcileCents,
   calculateBreakdown,
   calculateSettlement,
@@ -479,6 +482,84 @@ test('singlePayerId not in participants → no paid credit assigned', () => {
   // No one is credited as having paid, so everyone owes their full share to "nobody"
   // — net for both A and B is positive (they owe) but there's no creditor.
   assertEqual(txns.length, 0, 'no creditor → no transactions')
+})
+
+// ─── isValidAmount ────────────────────────────────────────────────────────────
+
+console.log('\nisValidAmount')
+
+test('empty string is valid (treated as 0)', () => {
+  assertEqual(isValidAmount(''), true, 'empty allowed')
+})
+test('whitespace-only is valid', () => {
+  assertEqual(isValidAmount('   '), true, 'whitespace allowed')
+})
+test('plain number is valid', () => {
+  assertEqual(isValidAmount('12.50'), true, 'flat dollar')
+})
+test('negative number is valid (discount)', () => {
+  assertEqual(isValidAmount('-5'), true, 'negative allowed')
+})
+test('percentage is valid', () => {
+  assertEqual(isValidAmount('20%'), true, 'percent allowed')
+})
+test('negative percentage is valid', () => {
+  assertEqual(isValidAmount('-10%'), true, 'negative percent allowed')
+})
+test('non-numeric string is invalid', () => {
+  assertEqual(isValidAmount('abc'), false, 'text rejected')
+})
+test('non-numeric percent is invalid', () => {
+  assertEqual(isValidAmount('abc%'), false, 'text% rejected')
+})
+test('Infinity is invalid', () => {
+  assertEqual(isValidAmount('Infinity'), false, 'Infinity rejected')
+})
+test('Infinity% is invalid', () => {
+  assertEqual(isValidAmount('Infinity%'), false, 'Infinity% rejected')
+})
+
+// ─── isValidPrice ─────────────────────────────────────────────────────────────
+
+console.log('\nisValidPrice')
+
+test('empty string is valid', () => {
+  assertEqual(isValidPrice(''), true, 'empty allowed')
+})
+test('positive number is valid', () => {
+  assertEqual(isValidPrice('9.99'), true, 'positive price')
+})
+test('zero is valid', () => {
+  assertEqual(isValidPrice('0'), true, 'zero price')
+})
+test('negative number is invalid (prices are non-negative)', () => {
+  assertEqual(isValidPrice('-5'), false, 'negative price rejected')
+})
+test('percentage string is invalid for prices', () => {
+  assertEqual(isValidPrice('10%'), false, '% rejected for price')
+})
+test('non-numeric string is invalid', () => {
+  assertEqual(isValidPrice('abc'), false, 'text rejected')
+})
+test('Infinity is invalid', () => {
+  assertEqual(isValidPrice('Infinity'), false, 'Infinity rejected')
+})
+
+// ─── getTotalFeeBase ──────────────────────────────────────────────────────────
+
+console.log('\ngetTotalFeeBase')
+
+test('pre-tax base returns subtotal only', () => {
+  assertEqual(getTotalFeeBase('pre-tax', 100, 10), 100, 'pre-tax ignores tax')
+})
+test('post-tax base returns subtotal + tax', () => {
+  assertEqual(getTotalFeeBase('post-tax', 100, 10), 110, 'post-tax adds tax')
+})
+test('pre-tax with zero tax is just subtotal', () => {
+  assertEqual(getTotalFeeBase('pre-tax', 50, 0), 50, 'pre-tax zero tax')
+})
+test('post-tax with zero tax is still subtotal', () => {
+  assertEqual(getTotalFeeBase('post-tax', 50, 0), 50, 'post-tax zero tax = subtotal')
 })
 
 // ─── Summary ──────────────────────────────────────────────────────────────────

--- a/src/utils/calculate.test.ts
+++ b/src/utils/calculate.test.ts
@@ -4,6 +4,7 @@
 import {
   getAmountEquivalent,
   parseAmount,
+  parsePaidAmount,
   isValidAmount,
   isValidPrice,
   getTotalFeeBase,
@@ -642,6 +643,23 @@ test('pre-tax with zero tax is just subtotal', () => {
 })
 test('post-tax with zero tax is still subtotal', () => {
   assertEqual(getTotalFeeBase('post-tax', 50, 0), 50, 'post-tax zero tax = subtotal')
+})
+
+// ─── parsePaidAmount ──────────────────────────────────────────────────────────
+
+console.log('\nparsePaidAmount')
+
+test('valid number string', () => {
+  assertEqual(parsePaidAmount('12.50'), 12.5, 'parses valid amount')
+})
+test('undefined returns 0', () => {
+  assertEqual(parsePaidAmount(undefined), 0, 'undefined → 0')
+})
+test('empty string returns 0', () => {
+  assertEqual(parsePaidAmount(''), 0, 'empty → 0')
+})
+test('non-numeric string returns 0', () => {
+  assertEqual(parsePaidAmount('abc'), 0, 'non-numeric → 0')
 })
 
 // ─── splitAmountInput ─────────────────────────────────────────────────────────

--- a/src/utils/calculate.test.ts
+++ b/src/utils/calculate.test.ts
@@ -444,11 +444,7 @@ test('three-way: transaction amounts are whole cents', () => {
   const bd = calculateBreakdown(s)
   const txns = calculateSettlement(s, bd)
   for (const t of txns) {
-    const cents = Math.round(t.amount * 100)
-    assertEqual(cents, Math.round(cents), `transaction ${t.fromId}→${t.toId} is whole cents`)
-    if (String(t.amount).includes('.') && String(t.amount).split('.')[1].length > 2) {
-      throw new Error(`${t.amount} has more than 2 decimal places`)
-    }
+    assertEqual(Math.round(t.amount * 100) / 100, t.amount, `transaction ${t.fromId}→${t.toId} is whole cents`)
   }
 })
 
@@ -482,6 +478,91 @@ test('singlePayerId not in participants → no paid credit assigned', () => {
   // No one is credited as having paid, so everyone owes their full share to "nobody"
   // — net for both A and B is positive (they owe) but there's no creditor.
   assertEqual(txns.length, 0, 'no creditor → no transactions')
+})
+
+test('settlement with overpayment: payer is owed the difference', () => {
+  const participants = [p('A'), p('B')]
+  const s = state({
+    participants,
+    items: [item('x', '10')],
+    payerMode: 'multiple',
+    amountPaid: { A: '12', B: '0' }, // A overpaid by $2
+  })
+  const bd = calculateBreakdown(s)
+  const txns = calculateSettlement(s, bd)
+  // A's grandTotal = 5, A paid 12, so net = 5-12 = -7 (owed $7)
+  // B's grandTotal = 5, B paid 0, so net = 5-0 = +5 (owes $5)
+  // Only B→A transaction because overpayment doesn't create a second creditor
+  assertEqual(txns.length, 1, 'one transaction')
+  assertEqual(txns[0].fromId, 'B', 'B pays')
+  assertEqual(txns[0].toId, 'A', 'to A')
+  assertEqual(txns[0].amount, 5, 'B pays their share')
+})
+
+test('settlement nets all within 0.005 threshold: no transactions', () => {
+  const participants = [p('A'), p('B')]
+  const s = state({
+    participants,
+    items: [item('x', '10')],
+    payerMode: 'multiple',
+    amountPaid: { A: '5.002', B: '4.998' }, // nets < 0.005, both within threshold
+  })
+  const bd = calculateBreakdown(s)
+  const txns = calculateSettlement(s, bd)
+  assertEqual(txns.length, 0, 'sub-cent nets produce no transactions')
+})
+
+// ─── calculateBreakdown (edge cases) ─────────────────────────────────────────
+
+console.log('\ncalculateBreakdown (edge cases)')
+
+test('additional fee on post-tax base', () => {
+  const s = state({
+    participants: [p('A'), p('B')],
+    items: [item('x', '10')],
+    tax: '10%', // $1 tax, totalSubtotal = $10, post-tax = $11
+    additionalFees: [fee('svc', '10%', 'post-tax')], // 10% of $11 = $1.10
+  })
+  const bd = calculateBreakdown(s)
+  assertEqual(bd.totalTax, 1, '$1 tax')
+  assertEqual(bd.totalAdditionalFees[0], 1.1, '10% of $11 post-tax = $1.10')
+})
+
+test('percentage fee when pool base is 0 splits evenly', () => {
+  // No items → subtotal = 0, fee base = 0, distributeProportionally falls back to even split
+  const s = state({
+    participants: [p('A'), p('B')],
+    items: [],
+    additionalFees: [fee('svc', '2')], // $2 flat fee with zero pool
+  })
+  const bd = calculateBreakdown(s)
+  assertEqual(bd.totalAdditionalFees[0], 2, '$2 fee')
+  assertEqual(bd.perPerson[0].additionalFees[0], 1, 'A pays half (even split)')
+  assertEqual(bd.perPerson[1].additionalFees[0], 1, 'B pays half (even split)')
+})
+
+test('3-way negative discount splits proportionally', () => {
+  const s = state({
+    participants: [p('A'), p('B'), p('C')],
+    items: [item('x', '30')], // $10 each
+    additionalFees: [fee('coupon', '-3')], // -$3 total = -$1 each
+  })
+  const bd = calculateBreakdown(s)
+  assertEqual(bd.totalAdditionalFees[0], -3, '-$3 discount')
+  for (const pp of bd.perPerson) {
+    assertEqual(pp.additionalFees[0], -1, 'each person saves $1')
+  }
+})
+
+test('item assigned to id not in participants is silently skipped', () => {
+  const s = state({
+    participants: [p('A'), p('B')],
+    items: [item('x', '10', ['ghost'])], // 'ghost' is not a participant
+  })
+  const bd = calculateBreakdown(s)
+  assertEqual(bd.totalSubtotal, 0, 'item with non-participant assignee contributes nothing')
+  assertEqual(bd.perPerson[0].subtotal, 0, 'A gets nothing')
+  assertEqual(bd.perPerson[1].subtotal, 0, 'B gets nothing')
 })
 
 // ─── isValidAmount ────────────────────────────────────────────────────────────

--- a/src/utils/calculate.test.ts
+++ b/src/utils/calculate.test.ts
@@ -661,6 +661,12 @@ test('empty string returns 0', () => {
 test('non-numeric string returns 0', () => {
   assertEqual(parsePaidAmount('abc'), 0, 'non-numeric → 0')
 })
+test('Infinity string returns 0', () => {
+  assertEqual(parsePaidAmount('Infinity'), 0, 'Infinity → 0')
+})
+test('-Infinity string returns 0', () => {
+  assertEqual(parsePaidAmount('-Infinity'), 0, '-Infinity → 0')
+})
 
 // ─── splitAmountInput ─────────────────────────────────────────────────────────
 

--- a/src/utils/calculate.test.ts
+++ b/src/utils/calculate.test.ts
@@ -9,6 +9,7 @@ import {
   calculateSettlement,
 } from './calculate'
 import type { BillState, Item, Participant, AdditionalFee } from '../types'
+import { test, assertEqual, summary } from '../test/harness'
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -42,27 +43,6 @@ function state(overrides: Partial<BillState> = {}): BillState {
 /** Sum per-person values to cents, for reconciliation assertions. */
 function sumCents(values: number[]): number {
   return values.reduce((a, b) => a + Math.round(b * 100), 0)
-}
-
-let passed = 0
-let failed = 0
-
-function test(name: string, fn: () => void) {
-  try {
-    fn()
-    console.log(`  ✓ ${name}`)
-    passed++
-  } catch (e) {
-    console.error(`  ✗ ${name}`)
-    console.error(`    ${e instanceof Error ? e.message : e}`)
-    failed++
-  }
-}
-
-function assertEqual<T>(actual: T, expected: T, label: string) {
-  const a = JSON.stringify(actual)
-  const b = JSON.stringify(expected)
-  if (a !== b) throw new Error(`${label}\n    expected: ${b}\n    actual:   ${a}`)
 }
 
 // ─── getAmountEquivalent ───────────────────────────────────────────────────
@@ -503,5 +483,4 @@ test('singlePayerId not in participants → no paid credit assigned', () => {
 
 // ─── Summary ──────────────────────────────────────────────────────────────────
 
-console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`)
-if (failed > 0) process.exit(1)
+summary()

--- a/src/utils/calculate.test.ts
+++ b/src/utils/calculate.test.ts
@@ -7,6 +7,7 @@ import {
   isValidAmount,
   isValidPrice,
   getTotalFeeBase,
+  splitAmountInput,
   reconcileCents,
   calculateBreakdown,
   calculateSettlement,
@@ -641,6 +642,29 @@ test('pre-tax with zero tax is just subtotal', () => {
 })
 test('post-tax with zero tax is still subtotal', () => {
   assertEqual(getTotalFeeBase('post-tax', 50, 0), 50, 'post-tax zero tax = subtotal')
+})
+
+// ─── splitAmountInput ─────────────────────────────────────────────────────────
+
+console.log('\nsplitAmountInput')
+
+test('plain number: not percent, numeric preserved', () => {
+  assertEqual(splitAmountInput('10.50'), { isPercent: false, numeric: '10.50' }, 'flat dollar')
+})
+test('percent string: isPercent true, % stripped', () => {
+  assertEqual(splitAmountInput('20%'), { isPercent: true, numeric: '20' }, 'percent')
+})
+test('bare %: isPercent true, numeric empty', () => {
+  assertEqual(splitAmountInput('%'), { isPercent: true, numeric: '' }, 'bare %')
+})
+test('empty string: not percent, numeric empty', () => {
+  assertEqual(splitAmountInput(''), { isPercent: false, numeric: '' }, 'empty')
+})
+test('whitespace trimmed', () => {
+  assertEqual(splitAmountInput('  15%  '), { isPercent: true, numeric: '15' }, 'trims before parsing')
+})
+test('negative percent', () => {
+  assertEqual(splitAmountInput('-10%'), { isPercent: true, numeric: '-10' }, 'negative percent')
 })
 
 // ─── Summary ──────────────────────────────────────────────────────────────────

--- a/src/utils/calculate.ts
+++ b/src/utils/calculate.ts
@@ -139,10 +139,10 @@ export function getTotalFeeBase(base: FeesBase, totalSubtotal: number, totalTax:
   return base === 'post-tax' ? totalSubtotal + totalTax : totalSubtotal
 }
 
-/** Parse a paid-amount string, treating empty/null/undefined/NaN as 0. */
+/** Parse a paid-amount string; empty, undefined, non-numeric, or non-finite values become 0. */
 export function parsePaidAmount(value: string | undefined): number {
   const n = Number(value ?? '')
-  return isNaN(n) ? 0 : n
+  return isFinite(n) ? n : 0
 }
 
 /**

--- a/src/utils/calculate.ts
+++ b/src/utils/calculate.ts
@@ -139,6 +139,12 @@ export function getTotalFeeBase(base: FeesBase, totalSubtotal: number, totalTax:
   return base === 'post-tax' ? totalSubtotal + totalTax : totalSubtotal
 }
 
+/** Parse a paid-amount string, treating empty/null/undefined/NaN as 0. */
+export function parsePaidAmount(value: string | undefined): number {
+  const n = Number(value ?? '')
+  return isNaN(n) ? 0 : n
+}
+
 /**
  * Distribute a proportional fee across participants.
  * Each person's share is proportional to their `base` amount vs the pool total.
@@ -234,18 +240,13 @@ export function calculateBreakdown(state: BillState): BillBreakdown {
     taxTotal,
   )
 
-  // Helper: resolve the base amount for a single person's proportional fee share
-  function getFeeBase(base: FeesBase, personSubtotal: number, personTax: number): number {
-    return base === 'post-tax' ? personSubtotal + personTax : personSubtotal
-  }
-
   // Tip
   const tipTotalBase = getTotalFeeBase(tipBase, totalSubtotal, taxTotal)
   const tipTotal = parseAmount(tip, tipTotalBase)
   const tipShares = reconcileCents(
     distributeProportionally(
       tipTotal,
-      participants.map((_p, i) => getFeeBase(tipBase, reconciledSubtotals[i], taxShares[i])),
+      participants.map((_p, i) => getTotalFeeBase(tipBase, reconciledSubtotals[i], taxShares[i])),
       tipTotalBase,
     ),
     tipTotal,
@@ -262,7 +263,7 @@ export function calculateBreakdown(state: BillState): BillBreakdown {
     return reconcileCents(
       distributeProportionally(
         totalAdditionalFees[fi],
-        participants.map((_p, i) => getFeeBase(fee.base, reconciledSubtotals[i], taxShares[i])),
+        participants.map((_p, i) => getTotalFeeBase(fee.base, reconciledSubtotals[i], taxShares[i])),
         feeBase,
       ),
       totalAdditionalFees[fi],
@@ -333,8 +334,7 @@ export function calculateSettlement(
     }
   } else {
     for (const p of participants) {
-      const val = Number(amountPaid[p.id] ?? '')
-      paid[p.id] = isNaN(val) ? 0 : val
+      paid[p.id] = parsePaidAmount(amountPaid[p.id])
     }
   }
 

--- a/src/utils/calculate.ts
+++ b/src/utils/calculate.ts
@@ -3,28 +3,37 @@ import type { BillState, FeesBase } from '../types'
 // ─── Parsing ────────────────────────────────────────────────────────────────
 
 /**
+ * Split a trimmed amount string into its percent flag and numeric part.
+ * A trailing "%" means percent mode; the numeric part has the "%" stripped.
+ */
+export function splitAmountInput(value: string): { isPercent: boolean; numeric: string } {
+  const trimmed = value.trim()
+  const isPercent = trimmed.endsWith('%')
+  return { isPercent, numeric: isPercent ? trimmed.slice(0, -1) : trimmed }
+}
+
+/**
  * Parse a user-entered amount string relative to a base dollar amount.
  * A trailing "%" means the value is a percentage of `base`.
  * Anything else is treated as a flat dollar amount.
  * Returns 0 for empty, unparseable, or NaN inputs.
  */
 export function parseAmount(value: string, base: number): number {
-  const trimmed = value.trim()
-  if (!trimmed) return 0
-  if (trimmed.endsWith('%')) {
-    const pct = Number(trimmed.slice(0, -1))
+  const { isPercent, numeric } = splitAmountInput(value)
+  if (!numeric && !isPercent) return 0
+  if (isPercent) {
+    const pct = Number(numeric)
     return isNaN(pct) ? 0 : (pct / 100) * base
   }
-  const n = Number(trimmed)
+  const n = Number(numeric)
   return isNaN(n) ? 0 : n
 }
 
 /** Returns true if a string is a syntactically valid amount ($ or %). */
 export function isValidAmount(value: string): boolean {
-  const trimmed = value.trim()
-  if (!trimmed) return true // empty is allowed (treated as 0)
-  const raw = trimmed.endsWith('%') ? trimmed.slice(0, -1) : trimmed
-  const n = Number(raw)
+  const { isPercent, numeric } = splitAmountInput(value)
+  if (!numeric && !isPercent) return true // empty is allowed (treated as 0)
+  const n = Number(numeric)
   return !isNaN(n) && isFinite(n)
 }
 
@@ -91,17 +100,15 @@ function formatPercent(n: number): string {
  * or a $-to-% conversion against a zero or negative base.
  */
 export function getAmountEquivalent(value: string, base: number): string | null {
-  const trimmed = value.trim()
-  if (!trimmed || !isFinite(base)) return null
-  const isPercent = trimmed.endsWith('%')
+  const { isPercent, numeric } = splitAmountInput(value)
+  if ((!numeric && !isPercent) || !isFinite(base)) return null
   if (isPercent) {
-    const numericPart = trimmed.slice(0, -1)
-    if (!numericPart) return null // bare "%" (e.g. mid-toggle with no digits yet)
-    const pct = Number(numericPart)
+    if (!numeric) return null // bare "%" (e.g. mid-toggle with no digits yet)
+    const pct = Number(numeric)
     if (isNaN(pct) || !isFinite(pct)) return null
     return formatDollar((pct / 100) * base)
   }
-  const n = Number(trimmed)
+  const n = Number(numeric)
   if (isNaN(n) || !isFinite(n) || base <= 0) return null
   return formatPercent((n / base) * 100)
 }

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,52 @@
+// Standalone test script for format utilities.
+// Run with: npm test
+
+import { formatAmount, formatMoney } from './format'
+import { test, assertEqual, summary } from '../test/harness'
+
+// ─── formatAmount ─────────────────────────────────────────────────────────────
+
+console.log('\nformatAmount')
+
+test('positive number, no $ prefix', () => {
+  assertEqual(formatAmount(5), '5.00', 'positive value')
+})
+test('zero', () => {
+  assertEqual(formatAmount(0), '0.00', 'zero')
+})
+test('negative uses U+2212 minus (not ASCII hyphen)', () => {
+  assertEqual(formatAmount(-5), '−5.00', 'Unicode minus before digits')
+})
+test('negative: sign precedes digits, no $', () => {
+  // U+2212 is the Unicode minus sign
+  const result = formatAmount(-3.50)
+  assertEqual(result, '−3.50', '−3.50')
+})
+test('rounding to 2 decimal places', () => {
+  assertEqual(formatAmount(1.005), '1.00', 'rounds to 2 decimals')
+})
+
+// ─── formatMoney ──────────────────────────────────────────────────────────────
+
+console.log('\nformatMoney')
+
+test('positive number with $ prefix', () => {
+  assertEqual(formatMoney(5), '$5.00', 'positive value')
+})
+test('zero', () => {
+  assertEqual(formatMoney(0), '$0.00', 'zero')
+})
+test('negative: Unicode minus precedes $, not after', () => {
+  // Should be −$5.00, not $-5.00
+  assertEqual(formatMoney(-5), '−$5.00', 'sign before $')
+})
+test('negative large amount', () => {
+  assertEqual(formatMoney(-100), '−$100.00', '−$100.00')
+})
+test('rounding to 2 decimal places', () => {
+  assertEqual(formatMoney(1.005), '$1.00', 'rounds to 2 decimals')
+})
+
+// ─── Summary ──────────────────────────────────────────────────────────────────
+
+summary()

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,18 +1,16 @@
-/**
- * Format a number as a plain decimal amount (no $ prefix).
- * Negative amounts use the Unicode minus sign so meaning isn't conveyed
- * by color alone (WCAG). Used in summary table cells and item share hints.
- */
-export function formatAmount(n: number): string {
-  return (n < 0 ? '−' : '') + Math.abs(n).toFixed(2)
+// Negative amounts use Unicode minus (U+2212) so the sign precedes $ and
+// meaning isn't conveyed by color alone (WCAG).
+
+function unsignedAmount(n: number): string {
+  return Math.abs(n).toFixed(2)
 }
 
-/**
- * Format a number as a dollar amount with $ prefix.
- * Negative amounts use the Unicode minus sign so the sign precedes $ (−$5.00,
- * not $-5.00) and meaning isn't conveyed by color alone (WCAG).
- * Used in payer inputs, settlement rows, and similar monetary displays.
- */
+/** Format a number as a plain decimal amount (no $ prefix). */
+export function formatAmount(n: number): string {
+  return (n < 0 ? '−' : '') + unsignedAmount(n)
+}
+
+/** Format a number as a dollar amount with $ prefix. */
 export function formatMoney(n: number): string {
-  return (n < 0 ? '−$' : '$') + Math.abs(n).toFixed(2)
+  return (n < 0 ? '−$' : '$') + unsignedAmount(n)
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,5 @@
-// Negative amounts use Unicode minus (U+2212) so the sign precedes $ and
-// meaning isn't conveyed by color alone (WCAG).
+// Negative amounts use Unicode minus (U+2212) so the sign precedes the currency
+// symbol when present, and meaning isn't conveyed by color alone (WCAG).
 
 function unsignedAmount(n: number): string {
   return Math.abs(n).toFixed(2)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/test/**"]
 }


### PR DESCRIPTION
Cleanup pass from a codebase-health review. Split into small commits so it's reviewable one fix at a time.

**Refactors (no behavior change)**
- Extract a shared percent/amount input parser; the same parse was reimplemented across 8 sites in \`calculate.ts\` and \`TaxTipSection\`.
- Share the paid-amount parser between settlement and the payer section; reuse the existing fee-base helper instead of a nested copy.
- Consolidate the currency formatters and drop the \`fmt\` aliases.
- Share the localStorage read/write try/catch between the versioned store and column-order hook.

**Tests**
- Add a shared test harness so the runner glue isn't copy-pasted across test files.
- Cover the previously-untested validators and formatters, plus breakdown/settlement edge cases (post-tax fees, zero-base splits, discounts, overpayment) and store/migration failure paths.
- Replace a tautological assertion in the settlement test.

**Robustness**
- Validate state restored from localStorage so a corrupt blob falls back instead of flowing into the math.
- Warn the user when changes can't be saved (private browsing / storage full) instead of failing silently.
- Cap participant, item, and fee name length.
- Drop an unsafe non-null assertion in item assignment.

**Tooling / docs**
- Scope the \`set-state-in-effect\` lint rule to its two legitimate uses instead of disabling it project-wide.
- Trim redundant and speculative comments.

Follow up: deciding whether to adopt Vitest + jsdom for hook/component coverage is tracked in #89.