### PR TITLE
fix: dispatch deploy after GITHUB_TOKEN writes to main

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -62,3 +62,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+
+      - name: Dispatch deploy for merged Dependabot PR
+        if: >-
+          steps.pr.outputs.skip != 'true' &&
+          (steps.pr.outputs.actor == 'dependabot[bot]' ||
+           steps.pr.outputs.actor == 'app/dependabot')
+        run: |
+          MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json mergeCommit --jq '.mergeCommit.oid')
+          if [ -z "$MERGE_SHA" ]; then
+            echo "Error: could not resolve merge commit SHA for PR #$PR_NUMBER — deploy dispatch failed."
+            exit 1
+          fi
+          gh workflow run deploy.yml --repo "$GITHUB_REPOSITORY" --ref main -f sha="$MERGE_SHA"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -48,6 +48,7 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
 
       - name: Dispatch auto-release for merged Dependabot PR
+        id: dispatch_release
         if: >-
           steps.pr.outputs.skip != 'true' &&
           (steps.pr.outputs.actor == 'dependabot[bot]' ||
@@ -58,6 +59,7 @@ jobs:
             echo "Error: could not resolve merge commit SHA for PR #$PR_NUMBER — auto-release dispatch failed."
             exit 1
           fi
+          echo "merge_sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
           gh workflow run auto-release.yml --repo "$GITHUB_REPOSITORY" --ref main -f sha="$MERGE_SHA"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,13 +70,7 @@ jobs:
           steps.pr.outputs.skip != 'true' &&
           (steps.pr.outputs.actor == 'dependabot[bot]' ||
            steps.pr.outputs.actor == 'app/dependabot')
-        run: |
-          MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json mergeCommit --jq '.mergeCommit.oid')
-          if [ -z "$MERGE_SHA" ]; then
-            echo "Error: could not resolve merge commit SHA for PR #$PR_NUMBER — deploy dispatch failed."
-            exit 1
-          fi
-          gh workflow run deploy.yml --repo "$GITHUB_REPOSITORY" --ref main -f sha="$MERGE_SHA"
+        run: gh workflow run deploy.yml --repo "$GITHUB_REPOSITORY" --ref main -f sha="$MERGE_SHA"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          MERGE_SHA: ${{ steps.dispatch_release.outputs.merge_sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,17 @@
 name: Deploy
 
-# Depends on ci.yml — only runs after CI passes on main.
+# Runs after CI passes on main (workflow_run), or dispatched directly by bot workflows.
 on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to deploy (defaults to HEAD of main)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -19,13 +25,17 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.sha || github.event.workflow_run.head_sha || github.sha }}
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,9 @@ concurrency:
 jobs:
   build-and-deploy:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/sync-node-version.yml
+++ b/.github/workflows/sync-node-version.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   sync:
@@ -25,12 +26,14 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Update .nvmrc
+        id: update
         run: |
           CURRENT=$(tr -d '[:space:]' < .nvmrc)
           NEW="${{ steps.node-version.outputs.version }}"
 
           if [ "$CURRENT" = "$NEW" ]; then
             echo ".nvmrc already up to date (${CURRENT}); nothing to commit."
+            echo "committed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -41,5 +44,14 @@ jobs:
           git add .nvmrc
           git commit -m "chore: sync .nvmrc to Chainguard node latest-dev (${NEW})"
           git push
+          echo "committed=true" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dispatch deploy for Node version sync
+        if: steps.update.outputs.committed == 'true'
+        run: |
+          COMMIT_SHA=$(git rev-parse HEAD)
+          gh workflow run deploy.yml --repo "$GITHUB_REPOSITORY" --ref main -f sha="$COMMIT_SHA"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Follow up to #86, which introduced the `auto-release.yml` dispatch pattern. Same root cause applies to `deploy.yml`: `dependabot-auto-merge.yml` and `sync-node-version.yml` both write to `main` using `GITHUB_TOKEN`, and GitHub doesn't fire new workflow runs for `GITHUB_TOKEN`-authored pushes. CI never runs on main after those commits, so `deploy.yml` (which gates on CI via `workflow_run`) never fires.

PRs #91–#95 are the evidence — all five merged on the same day with no deploy.

- Add `workflow_dispatch` to `deploy.yml` with an optional `sha` input so bot workflows can dispatch it directly. Also fixes the job `if:` condition (`workflow_run.conclusion == 'success'` evaluates to false on dispatch events) and pins the checkout ref via a three-way fallback: `inputs.sha || workflow_run.head_sha || github.sha`. The middle term matters: on `workflow_run` events, `github.sha` is the SHA the deploy workflow file was loaded from, not the commit CI tested.
- Add "Dispatch deploy" to `dependabot-auto-merge.yml` after each squash merge, using the same MERGE_SHA fetch-and-guard pattern as the sibling auto-release dispatch step.
- Add "Dispatch deploy" to `sync-node-version.yml` after a successful `.nvmrc` push, gated on a new `committed` output from the update step. Also adds `actions: write` to that workflow's permissions (previously only had `contents: write`).

The `workflow_dispatch` trigger also doubles as a manual "deploy main now" escape hatch from the Actions UI.