### PR TITLE
ci: group dependabot updates, plus small repo fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,16 @@ updates:
     labels:
       - "version:patch"
     open-pull-requests-limit: 10
+    # One grouped PR per run instead of one PR per dependency, so a weekly
+    # update batch produces a single release + deploy (auto-release.yml runs
+    # per merged PR).
+    groups:
+      npm-dependencies:
+        applies-to: version-updates
+        patterns: ["*"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +25,10 @@ updates:
     labels:
       - "version:patch"
     open-pull-requests-limit: 5
+    groups:
+      actions-dependencies:
+        applies-to: version-updates
+        patterns: ["*"]
+      actions-security:
+        applies-to: security-updates
+        patterns: ["*"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.vite/
 
 # Environment variables
 .env

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Other scripts:
 npm run build      # production build → dist/
 npm run preview    # preview the production build locally
 npm run typecheck  # run TypeScript without emitting files
+npm run lint       # run ESLint on src/
+npm test           # run the unit tests
 ```
 
 ### Docker

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧾</text></svg>" />
     <title>Bill Split</title>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧾</text></svg>" />
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.9em%22 font-size=%2290%22%3E🧾%3C/text%3E%3C/svg%3E" />
     <title>Bill Split</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
-    "test": "tsx src/lib/versionedStore.test.ts && tsx src/utils/calculate.test.ts && tsx src/utils/format.test.ts && tsx src/hooks/useBillSplit.test.ts"
+    "test": "tsx src/lib/versionedStore.test.ts && tsx src/utils/calculate.test.ts && tsx src/utils/format.test.ts && tsx src/hooks/useBillSplit.test.ts && tsx src/hooks/useColumnOrder.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
-    "test": "tsx src/lib/versionedStore.test.ts && tsx src/utils/calculate.test.ts && tsx src/utils/format.test.ts && tsx src/hooks/useBillSplit.test.ts && tsx src/hooks/useColumnOrder.test.ts"
+    "test": "tsx src/test/run-all.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.0",
   "_versionNote": "not used at runtime; releases and version numbers are managed via PR labels (version:minor, version:major) and git tags by .github/workflows/auto-release.yml",
   "type": "module",
+  "engines": {
+    "node": ">=26"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/src/hooks/useColumnOrder.test.ts
+++ b/src/hooks/useColumnOrder.test.ts
@@ -1,0 +1,56 @@
+// Pure-function tests for reconcileColumnOrder.
+// Run with: npm test
+
+import { reconcileColumnOrder } from './useColumnOrder'
+import { test, assertEqual, summary } from '../test/harness'
+
+console.log('\nreconcileColumnOrder')
+
+test('null (no stored order) falls back to insertion order', () => {
+  assertEqual(reconcileColumnOrder(null, ['a', 'b', 'c']), ['a', 'b', 'c'], 'insertion order')
+})
+
+test('non-array stored value falls back to insertion order', () => {
+  assertEqual(reconcileColumnOrder('garbage', ['a', 'b']), ['a', 'b'], 'string rejected')
+  assertEqual(reconcileColumnOrder({ a: 1 }, ['a', 'b']), ['a', 'b'], 'object rejected')
+  assertEqual(reconcileColumnOrder(42, ['a', 'b']), ['a', 'b'], 'number rejected')
+})
+
+test('stored custom order is preserved', () => {
+  assertEqual(reconcileColumnOrder(['c', 'a', 'b'], ['a', 'b', 'c']), ['c', 'a', 'b'], 'custom order kept')
+})
+
+test('duplicate ids in storage are deduplicated', () => {
+  assertEqual(reconcileColumnOrder(['a', 'b', 'a', 'b'], ['a', 'b']), ['a', 'b'], 'no duplicate columns')
+})
+
+test('ids of removed participants are dropped', () => {
+  assertEqual(reconcileColumnOrder(['gone', 'a', 'b'], ['a', 'b']), ['a', 'b'], 'stale id dropped')
+})
+
+test('new participants are appended at the end', () => {
+  assertEqual(reconcileColumnOrder(['b', 'a'], ['a', 'b', 'new']), ['b', 'a', 'new'], 'new id appended')
+})
+
+test('drop and append combine with order preserved', () => {
+  assertEqual(
+    reconcileColumnOrder(['gone', 'c', 'a'], ['a', 'b', 'c']),
+    ['c', 'a', 'b'],
+    'stale dropped, order kept, new appended'
+  )
+})
+
+test('non-string garbage in a stored array is filtered out', () => {
+  assertEqual(reconcileColumnOrder([1, null, 'a'], ['a', 'b']), ['a', 'b'], 'garbage entries dropped')
+})
+
+test('empty stored array yields insertion order', () => {
+  assertEqual(reconcileColumnOrder([], ['a', 'b']), ['a', 'b'], 'all appended')
+})
+
+test('no participants yields empty order', () => {
+  assertEqual(reconcileColumnOrder(['a', 'b'], []), [], 'empty result')
+  assertEqual(reconcileColumnOrder(null, []), [], 'empty fallback')
+})
+
+summary()

--- a/src/hooks/useColumnOrder.ts
+++ b/src/hooks/useColumnOrder.ts
@@ -5,6 +5,20 @@ import { readJSON, writeJSON } from '../lib/versionedStore'
 const COLUMN_ORDER_KEY = 'bill-split-column-order:v1'
 
 /**
+ * Reconciles a stored column order against the current participant ids:
+ * deduplicates (so corrupt/duplicate localStorage data can't produce
+ * duplicate columns), drops ids of removed participants, and appends new
+ * participants at the end. Non-array input falls back to insertion order.
+ */
+export function reconcileColumnOrder(stored: unknown, participantIds: string[]): string[] {
+  if (!Array.isArray(stored)) return [...participantIds]
+  const ids = [...new Set(stored as string[])]
+  const filtered = ids.filter(id => participantIds.includes(id))
+  const added = participantIds.filter(id => !ids.includes(id))
+  return [...filtered, ...added]
+}
+
+/**
  * Manages participant column display order, persisted to localStorage.
  *
  * Defaults to insertion order. New participants are appended; removed
@@ -15,29 +29,18 @@ export function useColumnOrder(participants: Participant[]): {
   setColumnOrder: React.Dispatch<React.SetStateAction<string[]>>
   orderedParticipants: Participant[]
 } {
-  const [columnOrder, setColumnOrder] = useState<string[]>(() => {
-    const allIds = participants.map(p => p.id)
-    const parsed = readJSON(COLUMN_ORDER_KEY)
-    if (Array.isArray(parsed)) {
-      // Deduplicate before filtering so corrupt/duplicate localStorage data
-      // can't produce duplicate columns.
-      const ids = [...new Set(parsed as string[])]
-      const filtered = ids.filter(id => allIds.includes(id))
-      const added = allIds.filter(id => !ids.includes(id))
-      return [...filtered, ...added]
-    }
-    return [...allIds]
-  })
+  const [columnOrder, setColumnOrder] = useState<string[]>(() =>
+    reconcileColumnOrder(readJSON(COLUMN_ORDER_KEY), participants.map(p => p.id))
+  )
 
   // Sync when participants are added or removed
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setColumnOrder(prev => {
-      const participantIds = participants.map(p => p.id)
-      const filtered = prev.filter(id => participantIds.includes(id))
-      const added = participantIds.filter(id => !prev.includes(id))
-      if (filtered.length === prev.length && added.length === 0) return prev
-      return [...filtered, ...added]
+      const next = reconcileColumnOrder(prev, participants.map(p => p.id))
+      // Keep the previous array when nothing changed so consumers don't re-render.
+      if (next.length === prev.length && next.every((id, i) => id === prev[i])) return prev
+      return next
     })
   }, [participants])
 

--- a/src/hooks/useColumnOrder.ts
+++ b/src/hooks/useColumnOrder.ts
@@ -12,7 +12,7 @@ const COLUMN_ORDER_KEY = 'bill-split-column-order:v1'
  */
 export function reconcileColumnOrder(stored: unknown, participantIds: string[]): string[] {
   if (!Array.isArray(stored)) return [...participantIds]
-  const ids = [...new Set(stored as string[])]
+  const ids = [...new Set(stored.filter((id): id is string => typeof id === 'string'))]
   const filtered = ids.filter(id => participantIds.includes(id))
   const added = participantIds.filter(id => !ids.includes(id))
   return [...filtered, ...added]

--- a/src/test/run-all.ts
+++ b/src/test/run-all.ts
@@ -1,0 +1,16 @@
+// Discovers and runs every *.test.ts under src/, replacing the && chain
+// that used to live in package.json. Each file runs in its own process so
+// the harness pass/fail counters stay per-file, matching the old behavior.
+import { globSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+
+const files = globSync('src/**/*.test.ts').sort()
+if (files.length === 0) {
+  console.error('no *.test.ts files found under src/')
+  process.exit(1)
+}
+
+for (const file of files) {
+  const result = spawnSync('tsx', [file], { stdio: 'inherit' })
+  if (result.status !== 0) process.exit(result.status ?? 1)
+}


### PR DESCRIPTION
Dependabot opens up to 10 separate npm PRs a week, and every merge mints its own release and Pages deploy. The [releases page](https://github.com/jglopez/bill-split/releases) is mostly dep-bump noise, and the deploys [trip over each other](https://github.com/jglopez/bill-split/deployments/github-pages). #96 already documented the symptom (#91-#95 all deployed the same day), and it happened again while this PR was open: #104, #105, and #107 merged within minutes of each other and cut v1.4.14 through v1.4.16.

## Summary

1. Group dependabot updates into one weekly PR per ecosystem. One grouped PR = one release + one deploy. This keeps the intent from #13 (dep updates ship as real versioned releases) and needs no workflow changes: grouped PRs still carry `version:patch` and are still authored by `dependabot[bot]`, so the auto-merge and dispatch chain from #86 and #96 works unchanged.
2. Declare `engines.node: ">=26"` in `package.json` so a local `npm install` on the wrong Node warns. Loose bound so the weekly `.nvmrc` bumps from `sync-node-version.yml` don't drift against it.
3. Add an inline SVG favicon to stop the `favicon.ico` 404 on every page load. Data URI, so no asset file, and it works under both `/bill-split/` on Pages and `/` in Docker.
4. Ignore `.vite/`. It's been in `.dockerignore` since #24 but never made it into `.gitignore`.
5. Document `npm run lint` and `npm test` in the README scripts block.
6. Extract the column-order dedupe/filter/append logic into a pure `reconcileColumnOrder()` and cover it on the existing tsx runner. This is the "cheap win regardless" path from #89, same pattern as `isBillState`.
7. Replace the `&&` chain in the `test` script with a small runner that globs `src/**/*.test.ts`, so new test files are picked up automatically. Each file still runs in its own process with the same failure semantics.

Each fix is its own commit. The last two commits before the runner are Copilot review fixes (type-guard filter instead of an `as` cast, percent-encoded angle brackets in the favicon URI).

## Testing

- `npm run typecheck`, `npm run lint`, `npm test`, and `npm run build` all green (160 tests across 5 suites via the new runner)
- Confirmed the runner exits non-zero when a test file fails
- Served the production build with `vite preview` and confirmed the favicon link ships in `dist/index.html`
- `dependabot.yml` parses cleanly; GitHub validates the groups schema on push, so I'll check the Dependabot tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
